### PR TITLE
Add combined test API for plants and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,13 @@ cd kaymaria
 npm install
 cp .env.local.example .env.local
 npm run dev
+```
+
+## 🔌 Test API
+
+A simple endpoint is available for experimenting with mock data:
+
+```bash
+curl http://localhost:3000/api/test
+```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ All items are unchecked to indicate upcoming work.
 - [x] Set up Supabase project and env keys (.env.local)
 - [ ] Run database migrations (Prisma)
 - [ ] Create seed scripts for mock data (plants, tasks)
-- [ ] Add test route to fetch plants and tasks
+- [x] Add test route to fetch plants and tasks
 
 ---
 

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { listPlants, getTasks } from "@/lib/mockdb";
+
+export async function GET() {
+  try {
+    const plants = listPlants();
+    const tasks = getTasks();
+    return NextResponse.json({ plants, tasks });
+  } catch (e) {
+    console.error("GET /api/test failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add /api/test route that returns mock plants and tasks
- document test API and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(warnings: Attempted import error: 'dump' is not exported from '@/lib/mockdb')*
- `npx tsc --noEmit` *(fails: Property 'value' does not exist on type 'EventTarget')*


------
https://chatgpt.com/codex/tasks/task_e_68a17a88ca448324bd2a2b3de1801722