### PR TITLE
fix: use PostgreSQL datasource

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,4 +2,4 @@
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-DATABASE_URL="file:./dev.db"
+DATABASE_URL="postgresql://user:password@host:5432/dbname"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- switch Prisma datasource provider from SQLite to PostgreSQL
- update example environment file with PostgreSQL connection string

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `DATABASE_URL='postgresql://postgres:Mikko612!@db.xegqimzrcdrhoxvlbnee.supabase.co:5432/postgres' npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68a186affe94832492194ed5a006e451