### PR TITLE
feat: allow completing tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,11 @@ curl -X POST http://localhost:3000/api/plants \\
   -d '{"name":"Palm","rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
 ```
 
+## ✅ Task API
+
+Tasks represent upcoming care actions for your plants.
+
+- `GET /api/tasks?window=7d` – list tasks due within the next N days (default `7d`)
+- `POST /api/tasks` – create a new task
+- `PATCH /api/tasks/:id` – mark a task as complete using either `t_<uuid>` or a composite `plantId:type` id. Completing a water task updates the plant's last watered date and schedules the next occurrence.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] Build CRUD endpoints for `/plants`
 - [x] Support plant onboarding with care defaults
 - [x] Add care intervals (water, fertilize, etc.)
-- [ ] Support marking tasks as complete
+- [x] Support marking tasks as complete
 
 ### 📅 Home View
 

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -11,20 +11,12 @@ export async function PATCH(
 
   const id = decodeURIComponent(params.id);
 
-  // If composite id "plantId:type", also update plant lastWaterAt
-  if (id.includes(":")) {
-    const [plantId, type] = id.split(":");
-    if (!plantId || !type) {
-      return NextResponse.json({ error: "bad id" }, { status: 400 });
-    }
-    if (type === "water") touchWatered(plantId);
-    // Also try to remove task if it matches any mock task id
-    completeTask(id);
-    return NextResponse.json({ ok: true });
+  const result = completeTask(id);
+  if (!result) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  // Normal task id
-  const ok = completeTask(id);
-  if (!ok) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (result.type === "water") touchWatered(result.plantId);
+
   return NextResponse.json({ ok: true });
 }

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -131,15 +131,21 @@ export function getTasks(windowDays = 7): TaskRec[] {
   return TASKS.filter(t => new Date(t.dueAt).getTime() <= maxTs);
 }
 
-export function completeTask(idOrComposite: string): boolean {
+export function completeTask(
+  idOrComposite: string
+): { plantId: string; type: CareType } | null {
   // Supports both "t_<uuid>" and "plantId:type"
-  const idx = TASKS.findIndex(t =>
-    t.id === idOrComposite ||
-    (idOrComposite.includes(":") && `${t.plantId}:${t.type}` === idOrComposite)
+  const idx = TASKS.findIndex(
+    (t) =>
+      t.id === idOrComposite ||
+      `${t.plantId}:${t.type}` === idOrComposite
   );
-  if (idx === -1) return false;
+  if (idx === -1) return null;
+  const task = TASKS[idx];
   TASKS.splice(idx, 1);
-  return true;
+  // Record care event and schedule the next task
+  addEvent(task.plantId, task.type);
+  return { plantId: task.plantId, type: task.type };
 }
 
 export function createTask(partial: Partial<TaskRec>): TaskRec {


### PR DESCRIPTION
## Summary
- add support for marking tasks complete and scheduling next care
- document task API and completion endpoint
- update roadmap to reflect task completion feature

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a186c993248324bac382365c28a963