### PR TITLE
feat: include overdue tasks in Today view

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 
 ## ✨ Features
 
-- 🌼 **Today View** – See exactly which plants need attention today
+ - 🌼 **Today View** – See exactly which plants need attention today, including overdue tasks
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ All items are **unchecked** to indicate upcoming work.
 
 ### 📅 Home View (Task Dashboard)
 
-- [ ] **Today view**: Show only tasks due today, including overdue ones
+- [x] **Today view**: Show only tasks due today, including overdue ones
 - [ ] **Upcoming view**: Show tasks due in the next 7 days (or a configurable range)
 - [ ] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
 - [ ] **Sort by urgency**: Sort tasks by due date/time within each plant group

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -251,11 +251,28 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   }
 
   const today = new Date();
-  const tasksToday = tasks.filter((t) => isSameDay(new Date(t.dueAt), today));
+  const tasksToday = useMemo(() => {
+    const tomorrow = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() + 1
+    );
+    return tasks
+      .filter((t) => new Date(t.dueAt) < tomorrow)
+      .sort(
+        (a, b) =>
+          new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime()
+      );
+  }, [tasks]);
   const upcoming = useMemo(() => {
+    const tomorrow = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() + 1
+    );
     const m = new Map<string, TaskDTO[]>();
     tasks
-      .filter((t) => !isSameDay(new Date(t.dueAt), today))
+      .filter((t) => new Date(t.dueAt) >= tomorrow)
       .forEach((t) => {
         const label = new Intl.DateTimeFormat(undefined, {
           weekday: "short",


### PR DESCRIPTION
## Summary
- show tasks due today or earlier in the Today view and keep future tasks in Upcoming
- document Today view behavior and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a18ae0855c8324adf6534e72dea0e7