### PR TITLE
Group tasks by plant in today view

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 
 ## ✨ Features
 
- - 🌼 **Today View** – See exactly which plants need attention today, including overdue tasks
- - 🌅 **Upcoming View** – Preview tasks due in the next 7 days (configurable)
+- 🌼 **Today View** – See exactly which plants need attention today, including overdue tasks
+- 🌅 **Upcoming View** – Preview tasks due in the next 7 days (configurable)
+- 🗂️ **Grouped Tasks** – Today's tasks organized by plant for quick scanning
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ All items are **unchecked** to indicate upcoming work.
 
 - [x] **Today view**: Show only tasks due today, including overdue ones
 - [x] **Upcoming view**: Show tasks due in the next 7 days (or a configurable range)
-- [ ] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
+- [x] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
 - [ ] **Sort by urgency**: Sort tasks by due date/time within each plant group
 - [ ] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
 - [ ] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -270,6 +270,13 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
           new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime()
       );
   }, [tasks]);
+  const tasksTodayGrouped = useMemo(() => {
+    const m = new Map<string, TaskDTO[]>();
+    tasksToday.forEach((t) => {
+      m.set(t.plantName, [...(m.get(t.plantName) || []), t]);
+    });
+    return Array.from(m.entries());
+  }, [tasksToday]);
   const upcoming = useMemo(() => {
     const tomorrow = new Date(
       today.getFullYear(),
@@ -357,17 +364,27 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
             )}
             {!loading &&
               !err &&
-              tasksToday.map((t) => (
-                <TaskRow
-                  key={t.id}
-                  plant={t.plantName}
-                  action={labelForType(t.type) as any}
-                  last={t.lastEventAt ? timeAgo(new Date(t.lastEventAt)) : "—"}
-                  due={dueLabel(new Date(t.dueAt), today)}
-                  onOpen={() => {}}
-                  onComplete={() => complete(t)}
-                  onDelete={() => remove(t)}
-                />
+              tasksTodayGrouped.map(([plantName, items]) => (
+                <div key={plantName} className="space-y-2">
+                  <div className="text-xs font-medium text-neutral-600 uppercase tracking-wide">
+                    {plantName}
+                  </div>
+                  <div className="space-y-3">
+                    {items.map((t) => (
+                      <TaskRow
+                        key={t.id}
+                        plant={t.plantName}
+                        action={labelForType(t.type) as any}
+                        last={t.lastEventAt ? timeAgo(new Date(t.lastEventAt)) : "—"}
+                        due={dueLabel(new Date(t.dueAt), today)}
+                        onOpen={() => {}}
+                        onComplete={() => complete(t)}
+                        onDelete={() => remove(t)}
+                        showPlant={false}
+                      />
+                    ))}
+                  </div>
+                </div>
               ))}
             {!loading && !err && tasksToday.length === 0 && (
               <div className="rounded-xl border bg-white shadow-sm p-6 text-center text-sm text-neutral-500">

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -1,1 +1,103 @@
-'use client'; import {motion} from 'framer-motion'; import {Check,Pencil,Trash2} from 'lucide-react'; export default function TaskRow({plant,action,last,due,onOpen,onComplete,onDelete}:{plant:string;action:'Water'|'Fertilize'|'Repot';last:string;due:string;onOpen:()=>void;onComplete:()=>void;onDelete:()=>void;}){return(<div className='relative'><div className='absolute inset-0 rounded-xl overflow-hidden'><div className='absolute inset-y-0 left-0 w-1/2 grid place-items-center bg-emerald-100 text-emerald-700'><div className='flex items-center gap-2 text-xs font-medium'><Check className='h-4 w-4'/>Complete</div></div><div className='absolute inset-y-0 right-0 w-1/2 grid place-items-center bg-red-100 text-red-600'><div className='flex items-center gap-2 text-xs font-medium'><Trash2 className='h-4 w-4'/>Delete</div></div></div><motion.div drag='x' dragConstraints={{left:-120,right:120}} dragElastic={0.2} onDragEnd={(_,i)=>{if(i.offset.x>80)onComplete(); else if(i.offset.x<-80)onDelete();}} className='relative'><div className='rounded-xl border bg-white shadow-sm'><div className='p-3 flex items-center gap-3'><button onClick={onOpen} className='h-10 w-10 rounded-xl bg-neutral-100 grid place-items-center'>🪴</button><div className='flex-1' onClick={onOpen}><div className='flex items-center justify-between'><div className='font-medium'>{plant}</div><span className='text-xs text-neutral-500'>{action}</span></div><div className='text-xs text-neutral-500'>Last: {last} • Due: {due}</div></div><div className='flex items-center gap-1'><button aria-label='Done' onClick={onComplete} className='p-2 rounded hover:bg-neutral-100'><Check className='h-4 w-4'/></button><button aria-label='Edit' onClick={onOpen} className='p-2 rounded hover:bg-neutral-100'><Pencil className='h-4 w-4'/></button><button aria-label='Delete' onClick={onDelete} className='p-2 rounded hover:bg-neutral-100'><Trash2 className='h-4 w-4'/></button></div></div></div></motion.div></div>);}
+'use client';
+
+import { motion } from 'framer-motion';
+import { Check, Pencil, Trash2 } from 'lucide-react';
+
+export default function TaskRow({
+  plant,
+  action,
+  last,
+  due,
+  onOpen,
+  onComplete,
+  onDelete,
+  showPlant = true,
+}: {
+  plant: string;
+  action: 'Water' | 'Fertilize' | 'Repot';
+  last: string;
+  due: string;
+  onOpen: () => void;
+  onComplete: () => void;
+  onDelete: () => void;
+  showPlant?: boolean;
+}) {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 rounded-xl overflow-hidden">
+        <div className="absolute inset-y-0 left-0 w-1/2 grid place-items-center bg-emerald-100 text-emerald-700">
+          <div className="flex items-center gap-2 text-xs font-medium">
+            <Check className="h-4 w-4" />
+            Complete
+          </div>
+        </div>
+        <div className="absolute inset-y-0 right-0 w-1/2 grid place-items-center bg-red-100 text-red-600">
+          <div className="flex items-center gap-2 text-xs font-medium">
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </div>
+        </div>
+      </div>
+      <motion.div
+        drag="x"
+        dragConstraints={{ left: -120, right: 120 }}
+        dragElastic={0.2}
+        onDragEnd={(_, i) => {
+          if (i.offset.x > 80) onComplete();
+          else if (i.offset.x < -80) onDelete();
+        }}
+        className="relative"
+      >
+        <div className="rounded-xl border bg-white shadow-sm">
+          <div className="p-3 flex items-center gap-3">
+            <button
+              onClick={onOpen}
+              className="h-10 w-10 rounded-xl bg-neutral-100 grid place-items-center"
+            >
+              🪴
+            </button>
+            <div className="flex-1" onClick={onOpen}>
+              {showPlant ? (
+                <div className="flex items-center justify-between">
+                  <div className="font-medium">{plant}</div>
+                  <span className="text-xs text-neutral-500">{action}</span>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between">
+                  <div className="font-medium">{action}</div>
+                </div>
+              )}
+              <div className="text-xs text-neutral-500">
+                Last: {last} • Due: {due}
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                aria-label="Done"
+                onClick={onComplete}
+                className="p-2 rounded hover:bg-neutral-100"
+              >
+                <Check className="h-4 w-4" />
+              </button>
+              <button
+                aria-label="Edit"
+                onClick={onOpen}
+                className="p-2 rounded hover:bg-neutral-100"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                aria-label="Delete"
+                onClick={onDelete}
+                className="p-2 rounded hover:bg-neutral-100"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- group today's tasks by plant and render each group with a header
- add optional `showPlant` prop to `TaskRow` to reuse rows without plant labels
- document grouped tasks feature and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1d9825bc083249e75e7156fb29cc3