### PR TITLE
feat: sort tasks by urgency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🌼 **Today View** – See exactly which plants need attention today, including overdue tasks
 - 🌅 **Upcoming View** – Preview tasks due in the next 7 days (configurable)
 - 🗂️ **Grouped Tasks** – Today's tasks organized by plant for quick scanning
+- ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Today view**: Show only tasks due today, including overdue ones
 - [x] **Upcoming view**: Show tasks due in the next 7 days (or a configurable range)
 - [x] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
-- [ ] **Sort by urgency**: Sort tasks by due date/time within each plant group
+- [x] **Sort by urgency**: Sort tasks by due date/time within each plant group
 - [ ] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
 - [ ] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
 - [ ] **Inline task actions**:

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -273,9 +273,22 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   const tasksTodayGrouped = useMemo(() => {
     const m = new Map<string, TaskDTO[]>();
     tasksToday.forEach((t) => {
-      m.set(t.plantName, [...(m.get(t.plantName) || []), t]);
+      const arr = m.get(t.plantName) || [];
+      arr.push(t);
+      m.set(t.plantName, arr);
     });
-    return Array.from(m.entries());
+    const groups = Array.from(m.entries()).map(([plant, items]) => [
+      plant,
+      items.sort(
+        (a, b) =>
+          new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime()
+      ),
+    ]) as [string, TaskDTO[]][];
+    groups.sort(
+      (a, b) =>
+        new Date(a[1][0].dueAt).getTime() - new Date(b[1][0].dueAt).getTime()
+    );
+    return groups;
   }, [tasksToday]);
   const upcoming = useMemo(() => {
     const tomorrow = new Date(


### PR DESCRIPTION
## Summary
- group today's tasks by plant and sort by upcoming due date
- document urgency sorting feature
- check off roadmap item for urgency sorting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1db09fbf8832485892ab63eec34a8