### PR TITLE
feat: add task icons for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🌅 **Upcoming View** – Preview tasks due in the next 7 days (configurable)
 - 🗂️ **Grouped Tasks** – Today's tasks organized by plant for quick scanning
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
+- 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Upcoming view**: Show tasks due in the next 7 days (or a configurable range)
 - [x] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
 - [x] **Sort by urgency**: Sort tasks by due date/time within each plant group
-- [ ] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
+- [x] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
 - [ ] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
 - [ ] **Inline task actions**:
   - [ ] Mark as done (with subtle animation or feedback)

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -22,6 +22,9 @@ export default function TaskRow({
   onDelete: () => void;
   showPlant?: boolean;
 }) {
+  function iconFor(action: 'Water' | 'Fertilize' | 'Repot') {
+    return action === 'Water' ? '💧' : action === 'Fertilize' ? '🌱' : '🪴';
+  }
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl overflow-hidden">
@@ -60,11 +63,17 @@ export default function TaskRow({
               {showPlant ? (
                 <div className="flex items-center justify-between">
                   <div className="font-medium">{plant}</div>
-                  <span className="text-xs text-neutral-500">{action}</span>
+                  <span className="text-xs text-neutral-500 flex items-center gap-1">
+                    <span>{iconFor(action)}</span>
+                    {action}
+                  </span>
                 </div>
               ) : (
                 <div className="flex items-center justify-between">
-                  <div className="font-medium">{action}</div>
+                  <div className="font-medium flex items-center gap-1">
+                    <span>{iconFor(action)}</span>
+                    {action}
+                  </div>
                 </div>
               )}
               <div className="text-xs text-neutral-500">


### PR DESCRIPTION
## Summary
- add icons for watering, fertilizing, and repotting tasks
- note task icons in README
- check off roadmap task icons item

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1dcfcfd4c832489b9f346b6ea762a