### PR TITLE
feat: add quick notes for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🗂️ **Grouped Tasks** – Today's tasks organized by plant for quick scanning
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
+- 📝 **Quick Notes** – Jot down observations directly from any task card
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care
@@ -108,6 +109,8 @@ Each plant also stores `waterIntervalDays` and `fertilizeIntervalDays` values to
 - `GET /api/plants/:id` – fetch a plant
 - `PATCH /api/plants/:id` – update fields on a plant
 - `DELETE /api/plants/:id` – remove a plant and its tasks
+- `GET /api/plants/:id/notes` – list notes for a plant
+- `POST /api/plants/:id/notes` – add a quick note
 
 Example:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
 - [x] **Sort by urgency**: Sort tasks by due date/time within each plant group
 - [x] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
-- [ ] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
+- [x] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
 - [ ] **Inline task actions**:
   - [ ] Mark as done (with subtle animation or feedback)
   - [ ] Defer (e.g., "Remind me tomorrow")

--- a/app/api/plants/[id]/notes/route.ts
+++ b/app/api/plants/[id]/notes/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { addNote, listNotes } from "@/lib/mockdb";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  return NextResponse.json(listNotes(params.id));
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const body = await req.json().catch(() => ({}));
+  const text = String(body.text || "").trim();
+  if (!text) {
+    return NextResponse.json({ error: "Missing text" }, { status: 400 });
+  }
+  const note = addNote(params.id, text);
+  return NextResponse.json(note, { status: 201 });
+}

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -220,6 +220,20 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
     });
   };
 
+  const addNote = async (plantId: string, text: string) => {
+    try {
+      const r = await fetch(`/api/plants/${plantId}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      if (!r.ok) throw new Error();
+      toast("Note added");
+    } catch {
+      toast("Failed to add note");
+    }
+  };
+
   const openAddPlant = (name: string) => {
     setAddOpen(false);
     setPrefillPlantName(name);
@@ -392,6 +406,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         due={dueLabel(new Date(t.dueAt), today)}
                         onOpen={() => {}}
                         onComplete={() => complete(t)}
+                        onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
                         showPlant={false}
                       />
@@ -443,6 +458,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         due={dueLabel(new Date(t.dueAt), today)}
                         onOpen={() => {}}
                         onComplete={() => complete(t)}
+                        onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
                       />
                     ))}

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Check, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 export default function TaskRow({
   plant,
@@ -10,6 +11,7 @@ export default function TaskRow({
   due,
   onOpen,
   onComplete,
+  onAddNote,
   onDelete,
   showPlant = true,
 }: {
@@ -19,12 +21,15 @@ export default function TaskRow({
   due: string;
   onOpen: () => void;
   onComplete: () => void;
+  onAddNote: (note: string) => void;
   onDelete: () => void;
   showPlant?: boolean;
 }) {
   function iconFor(action: 'Water' | 'Fertilize' | 'Repot') {
     return action === 'Water' ? '💧' : action === 'Fertilize' ? '🌱' : '🪴';
   }
+  const [noteOpen, setNoteOpen] = useState(false);
+  const [note, setNote] = useState('');
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl overflow-hidden">
@@ -89,8 +94,8 @@ export default function TaskRow({
                 <Check className="h-4 w-4" />
               </button>
               <button
-                aria-label="Edit"
-                onClick={onOpen}
+                aria-label="Add note"
+                onClick={() => setNoteOpen((v) => !v)}
                 className="p-2 rounded hover:bg-neutral-100"
               >
                 <Pencil className="h-4 w-4" />
@@ -105,6 +110,31 @@ export default function TaskRow({
             </div>
           </div>
         </div>
+        {noteOpen && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!note.trim()) return;
+              onAddNote(note.trim());
+              setNote('');
+              setNoteOpen(false);
+            }}
+            className="flex items-center gap-2 border-t p-3"
+          >
+            <input
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Quick note..."
+              className="flex-1 text-sm border rounded px-2 py-1"
+            />
+            <button
+              type="submit"
+              className="text-sm px-2 py-1 rounded bg-neutral-100"
+            >
+              Save
+            </button>
+          </form>
+        )}
       </motion.div>
     </div>
   );

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -20,6 +20,13 @@ export type Event = {
   at: string;           // ISO
 };
 
+export type Note = {
+  id: string;           // n_<uuid>
+  plantId: string;
+  text: string;
+  at: string;           // ISO
+};
+
 export type TaskRec = {
   id: string;           // t_<uuid>
   plantId: string;
@@ -62,6 +69,8 @@ let TASKS: TaskRec[] = [
   { id: `t_${uuid()}`, plantId: "p5", plantName: "Fern",   type: "water",     dueAt: new Date(now + 1*864e5).toISOString(), status: "due" },
   { id: `t_${uuid()}`, plantId: "p6", plantName: "Fiddle Fig", type: "water", dueAt: new Date(now + 3*864e5).toISOString(), status: "due" },
 ];
+
+let NOTES: Note[] = [];
 
 // ----- Query helpers -----
 export function listPlants(): Plant[] {
@@ -197,6 +206,24 @@ export function getLastEvent(plantId: string, type: CareType): Event | undefined
 export function getRule(plantId: string, type: CareType): Rule | undefined {
   const p = getPlant(plantId);
   return p?.rules.find(r => r.type === type);
+}
+
+// ----- Notes helpers -----
+export function addNote(plantId: string, text: string): Note {
+  const note: Note = {
+    id: `n_${uuid()}`,
+    plantId,
+    text,
+    at: new Date().toISOString(),
+  };
+  NOTES.push(note);
+  return note;
+}
+
+export function listNotes(plantId: string): Note[] {
+  return NOTES
+    .filter(n => n.plantId === plantId)
+    .sort((a, b) => new Date(b.at).getTime() - new Date(a.at).getTime());
 }
 
 export function getComputedWaterInfo(plantId: string): {


### PR DESCRIPTION
## Summary
- allow adding quick notes to tasks
- expose plant note API endpoints
- document quick notes feature and routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1de9f13348324b56308270e08f2d5