### PR TITLE
Add inline task deferral to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
 - 📝 **Quick Notes** – Jot down observations directly from any task card
+- ✅ **Inline Task Actions** – Mark tasks done or defer them without leaving the dashboard
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,8 +38,8 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
 - [x] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
 - [ ] **Inline task actions**:
-  - [ ] Mark as done (with subtle animation or feedback)
-  - [ ] Defer (e.g., "Remind me tomorrow")
+  - [x] Mark as done (with subtle animation or feedback)
+  - [x] Defer (e.g., "Remind me tomorrow")
   - [ ] Edit task details (date, type, etc.)
 - [ ] ** filters**: 
   - [ ] Filter by room/location

--- a/app/api/plants/[id]/notes/route.ts
+++ b/app/api/plants/[id]/notes/route.ts
@@ -3,14 +3,14 @@ import { addNote, listNotes } from "@/lib/mockdb";
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: any
 ) {
   return NextResponse.json(listNotes(params.id));
 }
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: any
 ) {
   const body = await req.json().catch(() => ({}));
   const text = String(body.text || "").trim();

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,34 +1,44 @@
 import { NextResponse } from "next/server";
-import { completeTask, addEvent, CareType } from "@/lib/mockdb";
+import { completeTask, addEvent, CareType, deferTask } from "@/lib/mockdb";
 import { touchWatered } from "@/lib/plantstore";
 
 // Accept both "t_<uuid>" and "plantId:type" (e.g. "p3:water")
-export async function PATCH(
-  _req: Request,
-  ctx: any
-) {
+export async function PATCH(req: Request, ctx: any) {
   const params = await ctx.params;
-
   const id = decodeURIComponent(params.id);
+  let body: any = null;
+  try {
+    body = await req.json();
+  } catch {}
 
-  // Try to find and remove a matching task
-  const rec = completeTask(id);
-  if (rec) {
-    if (rec.type === "water") touchWatered(rec.plantId);
-    addEvent(rec.plantId, rec.type);
-    return NextResponse.json({ ok: true });
+  if (body?.deferDays) {
+    const rec = deferTask(id, Number(body.deferDays));
+    if (!rec)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(rec);
   }
 
-  // If composite id "plantId:type", schedule next task even if no mock task existed
-  if (id.includes(":")) {
-    const [plantId, type] = id.split(":");
-    if (!plantId || !type) {
-      return NextResponse.json({ error: "bad id" }, { status: 400 });
+  if (body?.status === "done") {
+    const rec = completeTask(id);
+    if (rec) {
+      if (rec.type === "water") touchWatered(rec.plantId);
+      addEvent(rec.plantId, rec.type);
+      return NextResponse.json({ ok: true });
     }
-    if (type === "water") touchWatered(plantId);
-    addEvent(plantId, type as CareType);
-    return NextResponse.json({ ok: true });
+
+    // If composite id "plantId:type", schedule next task even if no mock task existed
+    if (id.includes(":")) {
+      const [plantId, type] = id.split(":");
+      if (!plantId || !type) {
+        return NextResponse.json({ error: "bad id" }, { status: 400 });
+      }
+      if (type === "water") touchWatered(plantId);
+      addEvent(plantId, type as CareType);
+      return NextResponse.json({ ok: true });
+    }
+
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json({ error: "Unsupported" }, { status: 400 });
 }

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -212,6 +212,23 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
     }
   };
 
+  const deferTask = async (t: TaskDTO) => {
+    try {
+      setTasks((prev) => prev.filter((x) => x.id !== t.id));
+      const r = await fetch(`/api/tasks/${encodeURIComponent(t.id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deferDays: 1 }),
+      });
+      if (!r.ok) throw new Error();
+      toast(`${labelForType(t.type)} • ${t.plantName} deferred`);
+      refresh();
+    } catch {
+      toast("Failed to defer");
+      refresh();
+    }
+  };
+
   const remove = (t: TaskDTO) => {
     setTasks((prev) => prev.filter((x) => x.id !== t.id));
     toast(`Dismissed • ${t.plantName}`, {
@@ -408,6 +425,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         onComplete={() => complete(t)}
                         onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
+                        onDefer={() => deferTask(t)}
                         showPlant={false}
                       />
                     ))}
@@ -460,6 +478,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         onComplete={() => complete(t)}
                         onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
+                        onDefer={() => deferTask(t)}
                       />
                     ))}
                   </div>

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Check, Pencil, Trash2 } from 'lucide-react';
+import { Check, Pencil, Trash2, Clock } from 'lucide-react';
 import { useState } from 'react';
 
 export default function TaskRow({
@@ -13,6 +13,7 @@ export default function TaskRow({
   onComplete,
   onAddNote,
   onDelete,
+  onDefer,
   showPlant = true,
 }: {
   plant: string;
@@ -23,6 +24,7 @@ export default function TaskRow({
   onComplete: () => void;
   onAddNote: (note: string) => void;
   onDelete: () => void;
+  onDefer: () => void;
   showPlant?: boolean;
 }) {
   function iconFor(action: 'Water' | 'Fertilize' | 'Repot') {
@@ -92,6 +94,13 @@ export default function TaskRow({
                 className="p-2 rounded hover:bg-neutral-100"
               >
                 <Check className="h-4 w-4" />
+              </button>
+              <button
+                aria-label="Defer"
+                onClick={onDefer}
+                className="p-2 rounded hover:bg-neutral-100"
+              >
+                <Clock className="h-4 w-4" />
               </button>
               <button
                 aria-label="Add note"

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -151,6 +151,15 @@ export function completeTask(idOrComposite: string): TaskRec | null {
   return rec;
 }
 
+export function deferTask(id: string, days: number): TaskRec | null {
+  const rec = TASKS.find(t => t.id === id);
+  if (!rec) return null;
+  const d = new Date(rec.dueAt);
+  d.setDate(d.getDate() + days);
+  rec.dueAt = d.toISOString();
+  return rec;
+}
+
 export function createTask(partial: Partial<TaskRec>): TaskRec {
   const id = `t_${uuid()}`;
   const rec: TaskRec = {


### PR DESCRIPTION
## Summary
- allow tasks to be deferred via new inline action
- update roadmap and README to reflect inline task actions
- adjust notes API handler typing and mock DB

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1f02f6768832491be266ee7f8da05