### PR TITLE
Enable inline editing of task details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
 - 📝 **Quick Notes** – Jot down observations directly from any task card
-- ✅ **Inline Task Actions** – Mark tasks done or defer them without leaving the dashboard
+- ✅ **Inline Task Actions** – Mark tasks done, defer them, or edit details without leaving the dashboard
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,10 +37,10 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Sort by urgency**: Sort tasks by due date/time within each plant group
 - [x] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
 - [x] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
-- [ ] **Inline task actions**:
+- [x] **Inline task actions**:
   - [x] Mark as done (with subtle animation or feedback)
   - [x] Defer (e.g., "Remind me tomorrow")
-  - [ ] Edit task details (date, type, etc.)
+  - [x] Edit task details (date, type, etc.)
 - [ ] ** filters**: 
   - [ ] Filter by room/location
   - [ ] Filter by task type

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { completeTask, addEvent, CareType, deferTask } from "@/lib/mockdb";
+import { completeTask, addEvent, CareType, deferTask, updateTask } from "@/lib/mockdb";
 import { touchWatered } from "@/lib/plantstore";
 
 // Accept both "t_<uuid>" and "plantId:type" (e.g. "p3:water")
@@ -38,6 +38,15 @@ export async function PATCH(req: Request, ctx: any) {
     }
 
     return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (body?.type || body?.dueAt) {
+    const rec = updateTask(id, {
+      type: body.type,
+      dueAt: body.dueAt,
+    });
+    if (!rec) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(rec);
   }
 
   return NextResponse.json({ error: "Unsupported" }, { status: 400 });

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -7,6 +7,7 @@ import Fab from "@/components/Fab";
 import TaskRow from "@/components/TaskRow";
 import QuickAddModal from "@/components/QuickAddModal";
 import AddPlantModal from "@/components/AddPlantModal";
+import EditTaskModal from "@/components/EditTaskModal";
 import { TaskDTO } from "@/lib/types";
 import { motion } from "framer-motion";
 
@@ -107,6 +108,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   const [addOpen, setAddOpen] = useState(false);
   const [addPlantOpen, setAddPlantOpen] = useState(false);
   const [prefillPlantName, setPrefillPlantName] = useState("");
+  const [editTask, setEditTask] = useState<TaskDTO | null>(null);
 
   // ui
   const [confetti, setConfetti] = useState<number[]>([]);
@@ -225,6 +227,39 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
       refresh();
     } catch {
       toast("Failed to defer");
+      refresh();
+    }
+  };
+
+  const updateTaskDetails = async (updates: {
+    action: "Water" | "Fertilize" | "Repot";
+    due: string;
+  }) => {
+    if (!editTask) return;
+    function optionToISO(opt: string) {
+      const d = new Date();
+      if (opt === "Tomorrow") d.setDate(d.getDate() + 1);
+      else if (opt.startsWith("In "))
+        d.setDate(d.getDate() + Number(opt.replace(/[^0-9]/g, "")));
+      return d.toISOString();
+    }
+    try {
+      const r = await fetch(`/api/tasks/${encodeURIComponent(editTask.id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: updates.action.toLowerCase(),
+          dueAt: optionToISO(updates.due),
+        }),
+      });
+      if (!r.ok) throw new Error();
+      const rec = await r.json();
+      setTasks((prev) => prev.map((t) => (t.id === rec.id ? rec : t)));
+      toast("Task updated");
+    } catch {
+      toast("Failed to update task");
+    } finally {
+      setEditTask(null);
       refresh();
     }
   };
@@ -426,6 +461,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
                         onDefer={() => deferTask(t)}
+                        onEdit={() => setEditTask(t)}
                         showPlant={false}
                       />
                     ))}
@@ -479,6 +515,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                         onAddNote={(note) => addNote(t.plantId, note)}
                         onDelete={() => remove(t)}
                         onDefer={() => deferTask(t)}
+                        onEdit={() => setEditTask(t)}
                       />
                     ))}
                   </div>
@@ -608,6 +645,21 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
           )}
         </div>
       )}
+
+      <EditTaskModal
+        open={!!editTask}
+        task={
+          editTask
+            ? {
+                plant: editTask.plantName,
+                action: labelForType(editTask.type) as any,
+                dueAt: editTask.dueAt,
+              }
+            : null
+        }
+        onClose={() => setEditTask(null)}
+        onSave={(u) => updateTaskDetails(u)}
+      />
 
       <QuickAddModal
         open={addOpen}

--- a/components/EditTaskModal.tsx
+++ b/components/EditTaskModal.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+export default function EditTaskModal({
+  open,
+  task,
+  onClose,
+  onSave,
+}:{
+  open: boolean;
+  task: { plant: string; action: 'Water'|'Fertilize'|'Repot'; dueAt: string } | null;
+  onClose: () => void;
+  onSave: (t:{ action:'Water'|'Fertilize'|'Repot'; due: string }) => void;
+}){
+  const [action, setAction] = useState<'Water'|'Fertilize'|'Repot'>('Water');
+  const [due, setDue] = useState('Today');
+
+  useEffect(() => {
+    if (task) {
+      setAction(task.action);
+      setDue(labelFromISO(task.dueAt));
+    }
+  }, [task]);
+
+  if (!open || !task) return null;
+
+  function labelFromISO(iso: string){
+    const today = new Date();
+    const due = new Date(iso);
+    const t0 = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const d0 = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+    const diff = Math.round((d0.getTime() - t0.getTime())/86400000);
+    if (diff <= 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    return `In ${diff}d`;
+  }
+
+  return (
+    <div
+      className='fixed inset-0 bg-black/30 grid place-items-center p-4'
+      onClick={(e)=>{ if(e.target===e.currentTarget) onClose(); }}
+    >
+      <div className='w-full max-w-md rounded-2xl bg-white p-4 shadow-xl'>
+        <div className='mb-2'>
+          <div className='text-lg font-semibold'>Edit Task</div>
+          <div className='text-sm text-neutral-600'>Update task details.</div>
+        </div>
+        <div className='grid gap-3'>
+          <div className='grid gap-1'>
+            <label className='text-sm'>Plant</label>
+            <div className='px-3 py-2 rounded bg-neutral-100 text-sm'>{task.plant}</div>
+          </div>
+          <div className='grid gap-1'>
+            <label className='text-sm'>Action</label>
+            <select className='border rounded px-3 py-2' value={action} onChange={e=>setAction(e.target.value as any)}>
+              <option>Water</option>
+              <option>Fertilize</option>
+              <option>Repot</option>
+            </select>
+          </div>
+          <div className='grid gap-1'>
+            <label className='text-sm'>Due</label>
+            <select className='border rounded px-3 py-2' value={due} onChange={e=>setDue(e.target.value)}>
+              <option>Today</option>
+              <option>Tomorrow</option>
+              <option>In 2d</option>
+            </select>
+          </div>
+        </div>
+        <div className='mt-3 flex gap-2 justify-end'>
+          <button className='border rounded px-3 py-2' onClick={onClose}>Cancel</button>
+          <button
+            className='bg-neutral-900 text-white rounded px-3 py-2'
+            onClick={()=>{ onSave({action, due}); onClose(); }}
+          >Save Changes</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Check, Pencil, Trash2, Clock } from 'lucide-react';
+import { Check, Trash2, Clock, Edit2, StickyNote } from 'lucide-react';
 import { useState } from 'react';
 
 export default function TaskRow({
@@ -14,6 +14,7 @@ export default function TaskRow({
   onAddNote,
   onDelete,
   onDefer,
+  onEdit,
   showPlant = true,
 }: {
   plant: string;
@@ -25,6 +26,7 @@ export default function TaskRow({
   onAddNote: (note: string) => void;
   onDelete: () => void;
   onDefer: () => void;
+  onEdit: () => void;
   showPlant?: boolean;
 }) {
   function iconFor(action: 'Water' | 'Fertilize' | 'Repot') {
@@ -103,11 +105,18 @@ export default function TaskRow({
                 <Clock className="h-4 w-4" />
               </button>
               <button
+                aria-label="Edit"
+                onClick={onEdit}
+                className="p-2 rounded hover:bg-neutral-100"
+              >
+                <Edit2 className="h-4 w-4" />
+              </button>
+              <button
                 aria-label="Add note"
                 onClick={() => setNoteOpen((v) => !v)}
                 className="p-2 rounded hover:bg-neutral-100"
               >
-                <Pencil className="h-4 w-4" />
+                <StickyNote className="h-4 w-4" />
               </button>
               <button
                 aria-label="Delete"

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -160,6 +160,14 @@ export function deferTask(id: string, days: number): TaskRec | null {
   return rec;
 }
 
+export function updateTask(id: string, updates: Partial<Pick<TaskRec, "type" | "dueAt" >>): TaskRec | null {
+  const rec = TASKS.find(t => t.id === id);
+  if (!rec) return null;
+  if (updates.type) rec.type = updates.type;
+  if (updates.dueAt) rec.dueAt = updates.dueAt;
+  return rec;
+}
+
 export function createTask(partial: Partial<TaskRec>): TaskRec {
   const id = `t_${uuid()}`;
   const rec: TaskRec = {


### PR DESCRIPTION
## Summary
- allow editing task type and due date via new EditTaskModal
- support PATCH updates for tasks on API and mock DB
- document completed roadmap item and feature description

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1f1a8aa648324a088161bac2d9076