### PR TITLE
Add room-based task filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🗂️ **Grouped Tasks** – Today's tasks organized by plant for quick scanning
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
+- 🏠 **Room Filters** – Focus on tasks for a specific room or location
 - 📝 **Quick Notes** – Jot down observations directly from any task card
 - ✅ **Inline Task Actions** – Mark tasks done, defer them, or edit details without leaving the dashboard
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Defer (e.g., "Remind me tomorrow")
   - [x] Edit task details (date, type, etc.)
 - [ ] ** filters**: 
-  - [ ] Filter by room/location
+  - [x] Filter by room/location
   - [ ] Filter by task type
   - [ ] Filter by overdue/urgent
 - [ ] **Mobile-first layout**: Design for one-handed thumb reach (FAB in lower right, swipe actions on cards)

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -129,6 +129,18 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   const [plantsErr, setPlantsErr] = useState<string | null>(null);
   const [plantsLoading, setPlantsLoading] = useState(false);
 
+  // room filter
+  const [roomFilter, setRoomFilter] = useState("");
+  const rooms = useMemo(() => {
+    const set = new Set<string>();
+    tasks.forEach((t) => set.add(t.roomId));
+    return Array.from(set);
+  }, [tasks]);
+  const filteredTasks = useMemo(
+    () => (roomFilter ? tasks.filter((t) => t.roomId === roomFilter) : tasks),
+    [tasks, roomFilter]
+  );
+
   async function refresh() {
     setLoading(true);
     setErr(null);
@@ -329,13 +341,13 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
       today.getMonth(),
       today.getDate() + 1
     );
-    return tasks
+    return filteredTasks
       .filter((t) => new Date(t.dueAt) < tomorrow)
       .sort(
         (a, b) =>
           new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime()
       );
-  }, [tasks]);
+  }, [filteredTasks]);
   const tasksTodayGrouped = useMemo(() => {
     const m = new Map<string, TaskDTO[]>();
     tasksToday.forEach((t) => {
@@ -368,7 +380,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
       today.getDate() + TASK_WINDOW_DAYS
     );
     const m = new Map<string, TaskDTO[]>();
-    tasks
+    filteredTasks
       .filter((t) => {
         const d = new Date(t.dueAt);
         return d >= tomorrow && d < windowEnd;
@@ -382,7 +394,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
         m.set(label, [...(m.get(label) || []), t]);
       });
     return Array.from(m.entries());
-  }, [tasks]);
+  }, [filteredTasks]);
 
   return (
     <div className="min-h-[100dvh] flex flex-col">
@@ -398,28 +410,44 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
           <ClientDate />
         </div>
         {view === "today" && (
-          <div className="mt-3 grid grid-cols-2 gap-2">
-            <button
-              className={
-                homeTab === "today"
-                  ? "bg-neutral-900 text-white rounded px-3 py-2"
-                  : "border rounded px-3 py-2"
-              }
-              onClick={() => setHomeTab("today")}
-            >
-              Today
-            </button>
-            <button
-              className={
-                homeTab === "upcoming"
-                  ? "bg-neutral-900 text-white rounded px-3 py-2"
-                  : "border rounded px-3 py-2"
-              }
-              onClick={() => setHomeTab("upcoming")}
-            >
-              Upcoming
-            </button>
-          </div>
+          <>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <button
+                className={
+                  homeTab === "today"
+                    ? "bg-neutral-900 text-white rounded px-3 py-2"
+                    : "border rounded px-3 py-2"
+                }
+                onClick={() => setHomeTab("today")}
+              >
+                Today
+              </button>
+              <button
+                className={
+                  homeTab === "upcoming"
+                    ? "bg-neutral-900 text-white rounded px-3 py-2"
+                    : "border rounded px-3 py-2"
+                }
+                onClick={() => setHomeTab("upcoming")}
+              >
+                Upcoming
+              </button>
+            </div>
+            <div className="mt-3">
+              <select
+                value={roomFilter}
+                onChange={(e) => setRoomFilter(e.target.value)}
+                className="border rounded px-3 py-2 w-full"
+              >
+                <option value="">All rooms</option>
+                {rooms.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </>
         )}
       </header>
 

--- a/lib/mockStore.ts
+++ b/lib/mockStore.ts
@@ -5,6 +5,7 @@ export type TaskDTO = {
   id: string;
   plantId: string;
   plantName: string;
+  roomId?: string;
   type: CareType;
   dueAt: string; // ISO
   status: "due";
@@ -38,6 +39,7 @@ function initialTasks(): TaskDTO[] {
       id: "t_seed_1",
       plantId: "p_orchid",
       plantName: "Orchid",
+      roomId: "room-1",
       type: "repot",
       dueAt: iso(today),
       status: "due",
@@ -70,6 +72,7 @@ export function listTasks(): TaskDTO[] {
 export function addTask(input: {
   plant: string;
   plantId?: string;
+  roomId?: string;
   type: CareType;
   dueAt: Date;
 }): TaskDTO {
@@ -83,6 +86,7 @@ export function addTask(input: {
     id,
     plantId,
     plantName: input.plant,
+    roomId: input.roomId,
     type: input.type,
     dueAt: input.dueAt.toISOString(),
     status: "due",

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -31,6 +31,7 @@ export type TaskRec = {
   id: string;           // t_<uuid>
   plantId: string;
   plantName: string;
+  roomId: string;
   type: CareType;
   dueAt: string;        // ISO
   status: "due";
@@ -63,11 +64,11 @@ let EVENTS: Event[] = [
 ];
 
 let TASKS: TaskRec[] = [
-  { id: `t_${uuid()}`, plantId: "p1", plantName: "Aloe",   type: "water",     dueAt: new Date(now).toISOString(), status: "due" },
-  { id: `t_${uuid()}`, plantId: "p3", plantName: "Orchid", type: "repot",     dueAt: new Date(now).toISOString(), status: "due", lastEventAt: EVENTS[0].at },
-  { id: `t_${uuid()}`, plantId: "p2", plantName: "Monstera", type: "water",   dueAt: new Date(now + 2*864e5).toISOString(), status: "due" },
-  { id: `t_${uuid()}`, plantId: "p5", plantName: "Fern",   type: "water",     dueAt: new Date(now + 1*864e5).toISOString(), status: "due" },
-  { id: `t_${uuid()}`, plantId: "p6", plantName: "Fiddle Fig", type: "water", dueAt: new Date(now + 3*864e5).toISOString(), status: "due" },
+  { id: `t_${uuid()}`, plantId: "p1", plantName: "Aloe", roomId: "living", type: "water", dueAt: new Date(now).toISOString(), status: "due" },
+  { id: `t_${uuid()}`, plantId: "p3", plantName: "Orchid", roomId: "bed", type: "repot", dueAt: new Date(now).toISOString(), status: "due", lastEventAt: EVENTS[0].at },
+  { id: `t_${uuid()}`, plantId: "p2", plantName: "Monstera", roomId: "living", type: "water", dueAt: new Date(now + 2*864e5).toISOString(), status: "due" },
+  { id: `t_${uuid()}`, plantId: "p5", plantName: "Fern", roomId: "living", type: "water", dueAt: new Date(now + 1*864e5).toISOString(), status: "due" },
+  { id: `t_${uuid()}`, plantId: "p6", plantName: "Fiddle Fig", roomId: "living", type: "water", dueAt: new Date(now + 3*864e5).toISOString(), status: "due" },
 ];
 
 let NOTES: Note[] = [];
@@ -170,10 +171,12 @@ export function updateTask(id: string, updates: Partial<Pick<TaskRec, "type" | "
 
 export function createTask(partial: Partial<TaskRec>): TaskRec {
   const id = `t_${uuid()}`;
+  const plant = getPlant(partial.plantId ?? "p_new");
   const rec: TaskRec = {
     id,
     plantId: partial.plantId ?? "p_new",
-    plantName: partial.plantName ?? "New Plant",
+    plantName: partial.plantName ?? plant?.name ?? "New Plant",
+    roomId: plant?.roomId ?? "unknown",
     type: (partial.type ?? "water") as CareType,
     dueAt: partial.dueAt ?? new Date().toISOString(),
     status: "due",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,1 +1,12 @@
-export type CareType='water'|'fertilize'|'repot'; export type TaskDTO={id:string;plantId:string;plantName:string;type:CareType;dueAt:string;status:'due';lastEventAt?:string};
+export type CareType = 'water' | 'fertilize' | 'repot';
+
+export type TaskDTO = {
+  id: string;
+  plantId: string;
+  plantName: string;
+  roomId: string;
+  type: CareType;
+  dueAt: string;
+  status: 'due';
+  lastEventAt?: string;
+};


### PR DESCRIPTION
## Summary
- allow filtering task list by room/location
- record room IDs on tasks in mock database and types
- document new room filter and update roadmap

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1f4ba6e4c8324bb557337804f4efc