### PR TITLE
feat: add task type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - ⏱️ **Urgency Sorting** – Tasks within each plant group are ordered by due date
 - 💧 **Task Icons** – Visual cues for watering, fertilizing, and repotting tasks
 - 🏠 **Room Filters** – Focus on tasks for a specific room or location
+- 🔍 **Task Type Filters** – Filter tasks by action (water, fertilize, repot)
 - 📝 **Quick Notes** – Jot down observations directly from any task card
 - ✅ **Inline Task Actions** – Mark tasks done, defer them, or edit details without leaving the dashboard
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,8 +42,8 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Defer (e.g., "Remind me tomorrow")
   - [x] Edit task details (date, type, etc.)
 - [ ] ** filters**: 
-  - [x] Filter by room/location
-  - [ ] Filter by task type
+- [x] Filter by room/location
+  - [x] Filter by task type
   - [ ] Filter by overdue/urgent
 - [ ] **Mobile-first layout**: Design for one-handed thumb reach (FAB in lower right, swipe actions on cards)
 

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -129,16 +129,27 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   const [plantsErr, setPlantsErr] = useState<string | null>(null);
   const [plantsLoading, setPlantsLoading] = useState(false);
 
-  // room filter
+  // room & type filters
   const [roomFilter, setRoomFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
   const rooms = useMemo(() => {
     const set = new Set<string>();
     tasks.forEach((t) => set.add(t.roomId));
     return Array.from(set);
   }, [tasks]);
+  const types = useMemo(() => {
+    const set = new Set<string>();
+    tasks.forEach((t) => set.add(t.type));
+    return Array.from(set);
+  }, [tasks]);
   const filteredTasks = useMemo(
-    () => (roomFilter ? tasks.filter((t) => t.roomId === roomFilter) : tasks),
-    [tasks, roomFilter]
+    () =>
+      tasks.filter(
+        (t) =>
+          (!roomFilter || t.roomId === roomFilter) &&
+          (!typeFilter || t.type === typeFilter)
+      ),
+    [tasks, roomFilter, typeFilter]
   );
 
   async function refresh() {
@@ -433,7 +444,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                 Upcoming
               </button>
             </div>
-            <div className="mt-3">
+            <div className="mt-3 space-y-2">
               <select
                 value={roomFilter}
                 onChange={(e) => setRoomFilter(e.target.value)}
@@ -443,6 +454,18 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
                 {rooms.map((r) => (
                   <option key={r} value={r}>
                     {r}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={typeFilter}
+                onChange={(e) => setTypeFilter(e.target.value)}
+                className="border rounded px-3 py-2 w-full"
+              >
+                <option value="">All task types</option>
+                {types.map((t) => (
+                  <option key={t} value={t}>
+                    {labelForType(t as any)}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
## Summary
- add task type filter and update task filtering logic
- document task type filters in README
- mark roadmap task as complete

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a235a393b483249864577e7b58e2ba