### PR TITLE
feat: mobile-first layout with safe areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 📍 **Smart Care Suggestions** – Based on light, pot size, species, and weather
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime
-- 📱 **Mobile-First UI** – Fast, clean, swipeable interface with offline support
+- 📱 **Mobile-First Layout** – Bottom navigation, floating action button, and swipeable task cards optimized for one-handed use
 - 🌤️ **Weather Awareness** – Adjust care based on location and evapotranspiration
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Filter by room/location
   - [x] Filter by task type
   - [x] Filter by overdue/urgent
-- [ ] **Mobile-first layout**: Design for one-handed thumb reach (FAB in lower right, swipe actions on cards)
+- [x] **Mobile-first layout**: Design for one-handed thumb reach (FAB in lower right, swipe actions on cards)
 
 
 ---

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -419,7 +419,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
   }, [filteredTasks]);
 
   return (
-    <div className="min-h-[100dvh] flex flex-col">
+    <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
       <header className="px-4 pt-6 pb-2 sticky top-0 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b">
         <div className="flex items-baseline justify-between w-full">
           <h1 className="text-xl font-semibold">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,17 @@
 import "./globals.css";
+import type { Metadata, Viewport } from "next";
 import { use } from "react";
+
+export const metadata: Metadata = {
+  title: "Kay Maria",
+  description: "Plant care companion",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
 
 export default function RootLayout({
   children,

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -37,7 +37,10 @@ export default function BottomNav({
   };
 
   return (
-    <nav className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t">
+    <nav
+      className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
       <div className="max-w-screen-sm mx-auto grid grid-cols-4">
         <Item tab="today" label="Today" icon={<IconLeaf />} />
         <Item tab="plants" label="Plants" icon={<IconCamera />} />

--- a/components/Fab.tsx
+++ b/components/Fab.tsx
@@ -1,1 +1,16 @@
-'use client'; import {Plus} from 'lucide-react'; export default function Fab({onClick}:{onClick:()=>void}){return <button onClick={onClick} className='fixed bottom-20 right-4 h-12 w-12 rounded-full bg-neutral-900 text-white grid place-items-center shadow-lg' aria-label='Add'><Plus className='h-5 w-5'/></button>;}
+'use client';
+
+import { Plus } from 'lucide-react';
+
+export default function Fab({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label="Add"
+      className="fixed right-4 h-12 w-12 rounded-full bg-neutral-900 text-white grid place-items-center shadow-lg"
+      style={{ bottom: `calc(5rem + env(safe-area-inset-bottom))` }}
+    >
+      <Plus className="h-5 w-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add viewport metadata and safe-area padding for mobile
- center app content and support fixed FAB
- document mobile-first layout and mark roadmap task complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a238a43e388324a458489755d1cba7