### PR TITLE
feat: add plant hero banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care
 - 📸 **Photo Uploads** – Track growth and keep a visual plant diary
+- 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 📍 **Smart Care Suggestions** – Based on light, pot size, species, and weather
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@ All items are **unchecked** to indicate upcoming work.
 
 ### 🌿 Plant Detail View
 
-- [ ] **Hero banner**: Show large plant photo, nickname, and species (optionally include age or acquired date)
+- [x] **Hero banner**: Show large plant photo, nickname, and species (optionally include age or acquired date)
 - [ ] **Quick Stats section**:
   - [ ] Watering interval & next due
   - [ ] Fertilizing interval & next due

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -27,9 +27,11 @@ function timeAgo(d: Date) {
   const mins = Math.floor(diff / 60000); return `${mins}m ago`;
 }
 
-export default function PlantDetailClient({ plant }: { plant: { id: string; name: string } }) {
+export default function PlantDetailClient({ plant }: { plant: { id: string; name: string; species?: string; photos?: string[]; acquiredAt?: string } }) {
   const id = plant.id;
   const [name] = useState(plant.name);
+  const photo = plant.photos?.[0] || "https://placehold.co/600x400?text=Plant";
+  const acquired = plant.acquiredAt ? new Date(plant.acquiredAt) : null;
   const [allTasks, setAllTasks] = useState<TaskDTO[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
@@ -100,10 +102,13 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
       <main className="flex-1 px-4 pb-28">
         {/* Hero */}
         <div className="rounded-2xl overflow-hidden border bg-white shadow-sm mt-4">
-          <div className="h-40 bg-neutral-200" />
+          <img src={photo} alt={name} className="h-40 w-full object-cover bg-neutral-200" />
           <div className="p-4">
             <h2 className="text-lg font-semibold">{name}</h2>
-            <div className="text-sm text-neutral-500">Room: — • Species: —</div>
+            <div className="text-sm text-neutral-500">
+              {plant.species || "—"}
+              {acquired && ` • Acquired ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(acquired)}`}
+            </div>
           </div>
         </div>
 

--- a/mock/plants.ts
+++ b/mock/plants.ts
@@ -10,7 +10,8 @@ export const mockPlants = [
     lastFertilized: "2025-08-01",
     nextFertilize: "2025-09-01",
     fertilizeIntervalDays: 30,
-    photos: [],
+    acquiredAt: "2024-03-01",
+    photos: ["https://placehold.co/600x400?text=Fiddle"],
     notes: [],
   },
   {
@@ -24,7 +25,8 @@ export const mockPlants = [
     lastFertilized: "2025-07-20",
     nextFertilize: "2025-08-20",
     fertilizeIntervalDays: 60,
-    photos: [],
+    acquiredAt: "2023-11-12",
+    photos: ["https://placehold.co/600x400?text=Snake"],
     notes: [],
   }
 ];


### PR DESCRIPTION
## Summary
- show plant photo and species in plant detail hero banner
- add acquisition date and sample photos to mock plant data
- check off completed roadmap item and document feature in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23b38e81c8324a565454bba31ecf0