### PR TITLE
Fix bottom navigation on plant detail pages

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -4,6 +4,7 @@ import type { Tab } from '@/components/BottomNav';
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import BottomNav from '@/components/BottomNav';
 
 type CareType = "water" | "fertilize" | "repot";
@@ -29,6 +30,7 @@ function timeAgo(d: Date) {
 
 export default function PlantDetailClient({ plant }: { plant: { id: string; name: string; species?: string; photos?: string[]; acquiredAt?: string } }) {
   const id = plant.id;
+  const router = useRouter();
   const [name] = useState(plant.name);
   const photo = plant.photos?.[0] || "https://placehold.co/600x400?text=Plant";
   const acquired = plant.acquiredAt ? new Date(plant.acquiredAt) : null;
@@ -157,7 +159,7 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
       </div>
 
       {/* Bottom nav */}
-      <BottomNav value="plants" onChange={() => {}} />
+      <BottomNav value="plants" onChange={(t: Tab) => router.push(`/app?tab=${t}`)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Enable bottom nav links on plant detail pages by routing to the main app view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23dfba1d48324a6ef9b7e4f9dbe87