### PR TITLE
feat: add plant notes journaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 📸 **Photo Uploads** – Track growth and keep a visual plant diary
 - 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos
+- 📓 **Plant Notes** – Journal free-form entries from the plant detail view
 - 📊 **Quick Stats** – At-a-glance summary of watering, fertilizing, and environment needs
 - 📍 **Smart Care Suggestions** – Based on light, pot size, species, and weather
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Tab layout**:
   - [x] **Quick Stats**: At-a-glance care summary
   - [x] **Timeline**: List of all completed and upcoming care tasks
-  - [ ] **Notes**: Free-form journaling or text entries
+  - [x] **Notes**: Free-form journaling or text entries
   - [ ] **Photos**: A visual gallery of growth over time
 - [ ] **Task completion feedback**:
   - [ ] Add a subtle animation when a task is marked done. don't use emojis

--- a/app/api/plants/[id]/notes/route.ts
+++ b/app/api/plants/[id]/notes/route.ts
@@ -1,22 +1,29 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { addNote, listNotes } from "@/lib/mockdb";
 
-export async function GET(
-  req: NextRequest,
-  { params }: any
-) {
-  return NextResponse.json(listNotes(params.id));
+// Fetch notes for a plant
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await ctx.params;
+    const notes = listNotes(id);
+    return NextResponse.json(notes);
+  } catch (e) {
+    console.error("GET /api/plants/[id]/notes failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
 }
 
-export async function POST(
-  req: NextRequest,
-  { params }: any
-) {
-  const body = await req.json().catch(() => ({}));
-  const text = String(body.text || "").trim();
-  if (!text) {
-    return NextResponse.json({ error: "Missing text" }, { status: 400 });
+// Add a note to a plant
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await ctx.params;
+    const body = await req.json().catch(() => ({}));
+    const text = typeof body.text === "string" ? body.text.trim() : "";
+    if (!text) return NextResponse.json({ error: "text required" }, { status: 400 });
+    const note = addNote(id, text);
+    return NextResponse.json(note, { status: 201 });
+  } catch (e) {
+    console.error("POST /api/plants/[id]/notes failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
   }
-  const note = addNote(params.id, text);
-  return NextResponse.json(note, { status: 201 });
 }

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -18,6 +18,8 @@ type TaskDTO = {
   lastEventAt?: string;
 };
 
+type Note = { id: string; text: string; at: string };
+
 export default function PlantDetailClient({ plant }: { plant: { id: string; name: string; species?: string; photos?: string[]; acquiredAt?: string; nextWater?: string; waterIntervalDays?: number; nextFertilize?: string; fertilizeIntervalDays?: number; light?: string; humidity?: string; potSize?: string; potMaterial?: string; soilType?: string } }) {
   const id = plant.id;
   const router = useRouter();
@@ -29,6 +31,8 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
   const [allTasks, setAllTasks] = useState<TaskDTO[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [tab, setTab] = useState<"stats" | "timeline" | "notes" | "photos">("stats");
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [noteText, setNoteText] = useState("");
 
   const fmt = (d: Date) => new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(d);
 
@@ -45,6 +49,19 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
     return () => { alive = false; };
   }, []);
 
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await fetch(`/api/plants/${id}/notes`, { cache: "no-store" });
+        if (!r.ok) throw new Error();
+        const data: Note[] = await r.json();
+        if (alive) setNotes(data);
+      } catch {}
+    })();
+    return () => { alive = false; };
+  }, [id]);
+
   const plantTasks = useMemo(() => (allTasks ?? []).filter(t => t.plantId === id), [allTasks, id]);
 
   const markWatered = async () => {
@@ -59,6 +76,22 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
       const r2 = await fetch(`/api/tasks?window=365d`, { cache: "no-store" });
       if (r2.ok) setAllTasks(await r2.json());
     } catch { /* keep UX smooth in mock */ }
+  };
+
+  const addNote = async () => {
+    const text = noteText.trim();
+    if (!text) return;
+    try {
+      const r = await fetch(`/api/plants/${id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      if (!r.ok) throw new Error();
+      const rec: Note = await r.json();
+      setNotes((n) => [rec, ...n]);
+      setNoteText("");
+    } catch {}
   };
 
   return (
@@ -179,8 +212,36 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
         )}
 
         {tab === "notes" && (
-          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4 text-sm text-neutral-500">
-            No notes yet
+          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4 text-sm">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                addNote();
+              }}
+            >
+              <textarea
+                value={noteText}
+                onChange={(e) => setNoteText(e.target.value)}
+                placeholder="Write a note..."
+                className="w-full border rounded p-2 text-sm"
+              />
+              <div className="text-right mt-2">
+                <button type="submit" className="px-3 py-1 rounded bg-neutral-900 text-white text-xs">
+                  Add Note
+                </button>
+              </div>
+            </form>
+            <ul className="mt-4 space-y-3">
+              {notes.length === 0 && <li className="text-neutral-500">No notes yet</li>}
+              {notes.map((n) => (
+                <li key={n.id} className="border-t pt-2 first:border-t-0 first:pt-0">
+                  <div>{n.text}</div>
+                  <div className="text-xs text-neutral-500">
+                    {new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(new Date(n.at))}
+                  </div>
+                </li>
+              ))}
+            </ul>
           </section>
         )}
 


### PR DESCRIPTION
## Summary
- enable plant-level notes with add and list endpoints
- add notes tab UI for journaling on plant detail view
- document notes feature in README and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23fe8981c8324bf1b433a09a37d33