### PR TITLE
feat: add plant photo gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care
-- 📸 **Photo Uploads** – Track growth and keep a visual plant diary
+- 📸 **Photo Gallery** – View plant photos over time to track growth
 - 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos
 - 📓 **Plant Notes** – Journal free-form entries from the plant detail view

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] **Quick Stats**: At-a-glance care summary
   - [x] **Timeline**: List of all completed and upcoming care tasks
   - [x] **Notes**: Free-form journaling or text entries
-  - [ ] **Photos**: A visual gallery of growth over time
+  - [x] **Photos**: A visual gallery of growth over time
 - [ ] **Task completion feedback**:
   - [ ] Add a subtle animation when a task is marked done. don't use emojis
   - [ ] Temporary confirmation message (e.g., “Watered!” with timestamp)

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -246,8 +246,21 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
         )}
 
         {tab === "photos" && (
-          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4 text-sm text-neutral-500">
-            No photos yet
+          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4">
+            {plant.photos && plant.photos.length > 0 ? (
+              <div className="grid grid-cols-3 gap-2">
+                {plant.photos.map((src, i) => (
+                  <img
+                    key={i}
+                    src={src}
+                    alt={`${plant.name} photo ${i + 1}`}
+                    className="w-full h-24 object-cover rounded"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-neutral-500 text-center">No photos yet</div>
+            )}
           </section>
         )}
 


### PR DESCRIPTION
## Summary
- show plant photos in a simple grid gallery
- document photo gallery and mark roadmap item complete

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a2416e0f088324890a12e285077672