### PR TITLE
Fix missing closing brace in PlantDetailClient

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -90,6 +90,7 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
       default:
         return <Sprout className={className} />;
     }
+  };
 
   const addNote = async () => {
     const text = noteText.trim();


### PR DESCRIPTION
## Summary
- close `iconFor` helper function in `PlantDetailClient`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a244a48140832490b94c179ed06af2