### PR TITLE
feat: add inline task completion with undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care
+- 🔁 **Timeline Task Completion** – Mark care tasks done directly from the timeline with undo support
 - 📸 **Photo Gallery** – View plant photos over time to track growth
 - 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,9 +69,9 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Task completion feedback**:
   - [x] Add a subtle animation when a task is marked done. don't use emojis
   - [x] Temporary confirmation message (e.g., “Watered!” with timestamp)
-- [ ] **Inline “Mark as Done” on Timeline**:
-  - [ ] Let users complete tasks directly from the timeline view
-  - [ ] Support undo in case of accidental tap
+- [x] **Inline “Mark as Done” on Timeline**:
+  - [x] Let users complete tasks directly from the timeline view
+  - [x] Support undo in case of accidental tap
 - [ ] **Mobile gesture support**:
   - [ ] Swipe to mark as done or edit a task
   - [ ] Tap-and-hold to add a journal entry or photo


### PR DESCRIPTION
## Summary
- allow marking plant timeline tasks complete with an undo option
- document timeline task completion feature
- check off roadmap item for timeline task completion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2441e9ab8832499e3208bd6f0b23c