### PR TITLE
feat: complete timeline tasks with undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - ⏳ **Timeline Journaling** – Visual history of waterings, notes, and care
+- 🔁 **Timeline Task Actions** – Complete tasks directly from the timeline with undo support
 - 📸 **Photo Gallery** – View plant photos over time to track growth
 - 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,9 +69,9 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Task completion feedback**:
   - [x] Add a subtle animation when a task is marked done. don't use emojis
   - [x] Temporary confirmation message (e.g., “Watered!” with timestamp)
-- [ ] **Inline “Mark as Done” on Timeline**:
-  - [ ] Let users complete tasks directly from the timeline view
-  - [ ] Support undo in case of accidental tap
+- [x] **Inline “Mark as Done” on Timeline**:
+  - [x] Let users complete tasks directly from the timeline view
+  - [x] Support undo in case of accidental tap
 - [ ] **Mobile gesture support**:
   - [ ] Swipe to mark as done or edit a task
   - [ ] Tap-and-hold to add a journal entry or photo

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -216,6 +216,12 @@ export function addEvent(plantId: string, type: CareType, at = new Date()): void
   });
 }
 
+export function undoTaskCompletion(task: TaskRec, eventAt: string): void {
+  EVENTS = EVENTS.filter(e => !(e.plantId === task.plantId && e.type === task.type && e.at === eventAt));
+  TASKS = TASKS.filter(t => !(t.plantId === task.plantId && t.type === task.type && t.lastEventAt === eventAt));
+  TASKS.push(task);
+}
+
 export function getLastEvent(plantId: string, type: CareType): Event | undefined {
   const events = EVENTS
     .filter(e => e.plantId === plantId && e.type === type)


### PR DESCRIPTION
## Summary
- allow marking plant timeline tasks complete with undo option
- support task completion undo via API and mock database
- document timeline task actions in README and roadmap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a2474b8c788324a5ed6e654b4e53d1