### PR TITLE
feat: add pot material field to plants

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ curl http://localhost:3000/api/test
 
 Basic CRUD endpoints exist for working with mock plant data. When creating a plant you can include default care rules, and initial tasks will be scheduled automatically.
 
-Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize` information.
+Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize` and `potMaterial` information.
 To enable local weather in the app, include `latitude` and `longitude` when creating a plant.
 
 - `GET /api/plants` – list all plants
@@ -133,7 +133,7 @@ Example:
 ```bash
 curl -X POST http://localhost:3000/api/plants \\
   -H 'Content-Type: application/json' \\
-  -d '{"name":"Palm","potSize":"10in","latitude":40.71,"longitude":-74.00,"rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
+  -d '{"name":"Palm","potSize":"10in","potMaterial":"plastic","latitude":40.71,"longitude":-74.00,"rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
 ```
 
 ## ✅ Task API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Repotting schedule
 - [ ] Input factors for recommendations:
   - [x] Pot size
-  - [ ] Pot material
+  - [x] Pot material
   - [ ] Soil type
   - [ ] Indoor light level
   - [ ] Room humidity

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: NextRequest) {
       roomId: body?.room ?? body?.roomId,
       species: body?.species,
       potSize: body?.potSize,
+      potMaterial: body?.potMaterial,
       rules: Array.isArray(body?.rules)
         ? body.rules.map((r: any) => ({
             type: r?.type,

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -30,6 +30,7 @@ export default function AddPlantModal({
   const [roomId, setRoomId] = useState(defaultRoomId);
   const [species, setSpecies] = useState('');
   const [pot, setPot] = useState('6 in');
+  const [potMaterial, setPotMaterial] = useState('Plastic');
   const [light, setLight] = useState('Medium');
   const [indoor, setIndoor] = useState<'Indoor'|'Outdoor'>('Indoor');
   const [drainage, setDrainage] = useState<'poor'|'ok'|'great'>('ok');
@@ -101,6 +102,7 @@ export default function AddPlantModal({
           roomId,
           species: species || undefined,
           potSize: pot,
+          potMaterial,
           lightLevel: light,
           indoor: indoor === 'Indoor',
           soilType: soil || undefined,
@@ -155,10 +157,15 @@ export default function AddPlantModal({
             <input className="input" value={species} onChange={e=>setSpecies(e.target.value)} placeholder="e.g., Monstera deliciosa" />
           </Field>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             <Field label="Pot size">
               <select className="input" value={pot} onChange={e=>setPot(e.target.value)}>
                 <option>4 in</option><option>6 in</option><option>8 in</option>
+              </select>
+            </Field>
+            <Field label="Pot material">
+              <select className="input" value={potMaterial} onChange={e=>setPotMaterial(e.target.value)}>
+                <option>Plastic</option><option>Terracotta</option><option>Ceramic</option>
               </select>
             </Field>
             <Field label="Light">

--- a/lib/mockStore.ts
+++ b/lib/mockStore.ts
@@ -18,6 +18,7 @@ export type PlantDTO = {
   roomId?: string;
   species?: string;
   potSize?: string;
+  potMaterial?: string;
   lightLevel?: string;
   indoor?: boolean;
   soilType?: string;

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -11,6 +11,7 @@ export type Plant = {
   roomId: string;
   species?: string;
   potSize?: string;
+  potMaterial?: string;
   rules: Rule[];
 };
 
@@ -57,6 +58,7 @@ let PLANTS: Plant[] = [
     roomId: "living",
     species: "Aloe vera",
     potSize: "6in",
+    potMaterial: "plastic",
     rules: [
       { type: "water", intervalDays: 7 },
       { type: "fertilize", intervalDays: 30 },
@@ -68,6 +70,7 @@ let PLANTS: Plant[] = [
     roomId: "living",
     species: "Monstera deliciosa",
     potSize: "8in",
+    potMaterial: "terracotta",
     rules: [
       { type: "water", intervalDays: 5 },
       { type: "fertilize", intervalDays: 28 },
@@ -79,6 +82,7 @@ let PLANTS: Plant[] = [
     roomId: "bed",
     species: "Phalaenopsis",
     potSize: "4in",
+    potMaterial: "ceramic",
     rules: [
       { type: "water", intervalDays: 10 },
       { type: "fertilize", intervalDays: 45 },
@@ -90,6 +94,7 @@ let PLANTS: Plant[] = [
     roomId: "bed",
     species: "Sansevieria",
     potSize: "6in",
+    potMaterial: "plastic",
     rules: [
       { type: "water", intervalDays: 14 },
     ],
@@ -100,6 +105,7 @@ let PLANTS: Plant[] = [
     roomId: "living",
     species: "Boston fern",
     potSize: "6in",
+    potMaterial: "ceramic",
     rules: [
       { type: "water", intervalDays: 3 },
     ],
@@ -110,6 +116,7 @@ let PLANTS: Plant[] = [
     roomId: "living",
     species: "Ficus lyrata",
     potSize: "10in",
+    potMaterial: "plastic",
     rules: [
       { type: "water", intervalDays: 7 },
     ],
@@ -145,6 +152,7 @@ export function createPlant(partial: {
   roomId?: string;
   species?: string;
   potSize?: string;
+  potMaterial?: string;
   rules?: Rule[];
 }): Plant {
   const id = `p_${uuid()}`;
@@ -154,6 +162,7 @@ export function createPlant(partial: {
     roomId: partial.roomId ?? "living",
     species: partial.species,
     potSize: partial.potSize,
+    potMaterial: partial.potMaterial,
     rules: partial.rules ?? [],
   };
   PLANTS.push(plant);
@@ -183,6 +192,7 @@ export function updatePlant(id: string, updates: Partial<Omit<Plant, "id" | "rul
   if (updates.roomId !== undefined) p.roomId = updates.roomId;
   if (updates.species !== undefined) p.species = updates.species;
   if (updates.potSize !== undefined) p.potSize = updates.potSize;
+  if (updates.potMaterial !== undefined) p.potMaterial = updates.potMaterial;
   if (updates.rules !== undefined) p.rules = updates.rules;
   return p;
 }


### PR DESCRIPTION
## Summary
- allow specifying a pot's material when creating plants
- surface pot material in add plant modal and mock database
- document new field and mark roadmap item complete

## Testing
- `npm test` (fails: Missing script: "test")
- `OPENAI_API_KEY=dummy npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a2577bd9ac83248616176ca4a9b19f