### PR TITLE
feat: add soil type to plant model

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ curl http://localhost:3000/api/test
 
 Basic CRUD endpoints exist for working with mock plant data. When creating a plant you can include default care rules, and initial tasks will be scheduled automatically.
 
-Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize` and `potMaterial` information.
+Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize`, `potMaterial`, and `soilType` information.
 To enable local weather in the app, include `latitude` and `longitude` when creating a plant.
 
 - `GET /api/plants` – list all plants
@@ -133,7 +133,7 @@ Example:
 ```bash
 curl -X POST http://localhost:3000/api/plants \\
   -H 'Content-Type: application/json' \\
-  -d '{"name":"Palm","potSize":"10in","potMaterial":"plastic","latitude":40.71,"longitude":-74.00,"rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
+  -d '{"name":"Palm","potSize":"10in","potMaterial":"plastic","soilType":"well-draining","latitude":40.71,"longitude":-74.00,"rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
 ```
 
 ## ✅ Task API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ All items are **unchecked** to indicate upcoming work.
 - [ ] Input factors for recommendations:
   - [x] Pot size
   - [x] Pot material
-  - [ ] Soil type
+  - [x] Soil type
   - [ ] Indoor light level
   - [ ] Room humidity
   - [ ] Seasonal changes

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -19,6 +19,7 @@ export async function POST(req: NextRequest) {
       species: body?.species,
       potSize: body?.potSize,
       potMaterial: body?.potMaterial,
+      soilType: body?.soilType,
       rules: Array.isArray(body?.rules)
         ? body.rules.map((r: any) => ({
             type: r?.type,

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -12,6 +12,7 @@ export type Plant = {
   species?: string;
   potSize?: string;
   potMaterial?: string;
+  soilType?: string;
   rules: Rule[];
 };
 
@@ -59,6 +60,7 @@ let PLANTS: Plant[] = [
     species: "Aloe vera",
     potSize: "6in",
     potMaterial: "plastic",
+    soilType: "cactus mix",
     rules: [
       { type: "water", intervalDays: 7 },
       { type: "fertilize", intervalDays: 30 },
@@ -71,6 +73,7 @@ let PLANTS: Plant[] = [
     species: "Monstera deliciosa",
     potSize: "8in",
     potMaterial: "terracotta",
+    soilType: "aroid mix",
     rules: [
       { type: "water", intervalDays: 5 },
       { type: "fertilize", intervalDays: 28 },
@@ -83,6 +86,7 @@ let PLANTS: Plant[] = [
     species: "Phalaenopsis",
     potSize: "4in",
     potMaterial: "ceramic",
+    soilType: "orchid bark",
     rules: [
       { type: "water", intervalDays: 10 },
       { type: "fertilize", intervalDays: 45 },
@@ -95,6 +99,7 @@ let PLANTS: Plant[] = [
     species: "Sansevieria",
     potSize: "6in",
     potMaterial: "plastic",
+    soilType: "sandy mix",
     rules: [
       { type: "water", intervalDays: 14 },
     ],
@@ -106,6 +111,7 @@ let PLANTS: Plant[] = [
     species: "Boston fern",
     potSize: "6in",
     potMaterial: "ceramic",
+    soilType: "peaty mix",
     rules: [
       { type: "water", intervalDays: 3 },
     ],
@@ -117,6 +123,7 @@ let PLANTS: Plant[] = [
     species: "Ficus lyrata",
     potSize: "10in",
     potMaterial: "plastic",
+    soilType: "rich potting mix",
     rules: [
       { type: "water", intervalDays: 7 },
     ],
@@ -153,6 +160,7 @@ export function createPlant(partial: {
   species?: string;
   potSize?: string;
   potMaterial?: string;
+  soilType?: string;
   rules?: Rule[];
 }): Plant {
   const id = `p_${uuid()}`;
@@ -163,6 +171,7 @@ export function createPlant(partial: {
     species: partial.species,
     potSize: partial.potSize,
     potMaterial: partial.potMaterial,
+    soilType: partial.soilType,
     rules: partial.rules ?? [],
   };
   PLANTS.push(plant);
@@ -193,6 +202,7 @@ export function updatePlant(id: string, updates: Partial<Omit<Plant, "id" | "rul
   if (updates.species !== undefined) p.species = updates.species;
   if (updates.potSize !== undefined) p.potSize = updates.potSize;
   if (updates.potMaterial !== undefined) p.potMaterial = updates.potMaterial;
+  if (updates.soilType !== undefined) p.soilType = updates.soilType;
   if (updates.rules !== undefined) p.rules = updates.rules;
   return p;
 }


### PR DESCRIPTION
## Summary
- support soil type on mock plant records and create/update helpers
- accept `soilType` when creating plants via API
- document soilType in README and mark roadmap task complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `OPENAI_API_KEY=dummy npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a259a7c1908324b20f4338eedf4aaf