### PR TITLE
feat(ai): include humidity in care recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos
 - 📓 **Plant Notes** – Journal free-form entries from the plant detail view
 - 📊 **Quick Stats** – At-a-glance summary of watering, fertilizing, and environment needs
-- 📍 **Smart Care Suggestions** – Based on light, pot size, species, and weather
+- 📍 **Smart Care Suggestions** – Based on light, humidity, pot size, species, and weather
 - 💧 **ET₀‑Aware Watering** – Adjusts suggested watering intervals using local evapotranspiration data
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime
@@ -116,7 +116,7 @@ curl http://localhost:3000/api/test
 
 Basic CRUD endpoints exist for working with mock plant data. When creating a plant you can include default care rules, and initial tasks will be scheduled automatically.
 
-Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize`, `potMaterial`, and `soilType` information.
+Each plant also stores `waterIntervalDays`, `fertilizeIntervalDays`, and optional `potSize`, `potMaterial`, `soilType`, `light`, and `humidity` information.
 To enable local weather in the app, include `latitude` and `longitude` when creating a plant.
 
 - `GET /api/plants` – list all plants
@@ -157,7 +157,7 @@ Request plant-specific care guidance powered by OpenAI:
 ```bash
 curl -X POST http://localhost:3000/api/ai/care-recommend \\
   -H 'Content-Type: application/json' \\
-  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect"}'
+  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium"}'
 ```
 
 This returns JSON with recommended `water`, `fertilizer`, `light`, and `repot` fields.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,8 +96,8 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Pot size
   - [x] Pot material
   - [x] Soil type
-  - [ ] Indoor light level
-  - [ ] Room humidity
+  - [x] Indoor light level
+  - [x] Room humidity
   - [ ] Seasonal changes
   - [ ] Plant location (room/outdoor/etc.)
 - [ ] Learn from user input:

--- a/app/api/ai/care-recommend/route.ts
+++ b/app/api/ai/care-recommend/route.ts
@@ -17,6 +17,7 @@ export async function POST(req: NextRequest) {
   const potMaterial = body.potMaterial ?? "plastic";
   const soilType = body.soilType ?? "well-draining";
   const lightLevel = body.lightLevel ?? "medium";
+  const humidity = body.humidity ?? "medium";
 
   try {
     const completion = await client.chat.completions.create({
@@ -27,10 +28,10 @@ export async function POST(req: NextRequest) {
           content:
             "You are a helpful plant care assistant that replies in JSON.",
         },
-        {
-          role: "user",
-          content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
-        },
+          {
+            role: "user",
+            content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
+          },
       ],
       response_format: { type: "json_object" },
     });


### PR DESCRIPTION
## Summary
- include optional humidity in AI care recommendation endpoint
- document humidity support in README
- check off roadmap items for indoor light level and room humidity

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a25b53d560832499479088ebb6f8dd