### PR TITLE
feat: add Cabinet Grotesk font

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -415,7 +415,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
     <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
       <header className="px-4 pt-6 pb-2 sticky top-0 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b">
         <div className="flex items-baseline justify-between w-full">
-          <h1 className="text-xl font-semibold">
+          <h1 className="text-xl font-display font-semibold">
             {view === "today"
               ? homeTab === "today"
                 ? "Today"
@@ -596,7 +596,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"plants
         {view === "plants" && (
           <section className="mt-4 space-y-6">
             <div className="flex items-center justify-between mb-2">
-              <h2 className="text-sm font-medium text-neutral-600">My Plants</h2>
+              <h2 className="text-sm font-display font-medium text-neutral-600">My Plants</h2>
               {plantsLoading && (
                 <span className="text-xs text-neutral-500">Loading…</span>
               )}

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -184,7 +184,7 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
             <ArrowLeft className="h-5 w-5" />
           </Link>
           <div className="flex items-baseline justify-between w-full">
-            <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
+            <h1 className="text-xl font-display font-semibold tracking-tight">{name}</h1>
             <span className="text-sm text-neutral-500">
               {new Intl.DateTimeFormat(undefined, { weekday:"short", month:"short", day:"numeric" }).format(new Date())}
             </span>
@@ -198,7 +198,7 @@ export default function PlantDetailClient({ plant }: { plant: { id: string; name
         <div className="rounded-2xl overflow-hidden border bg-white shadow-sm mt-4">
           <img src={photo} alt={name} className="h-40 w-full object-cover bg-neutral-200" />
           <div className="p-4">
-            <h2 className="text-lg font-semibold">{name}</h2>
+            <h2 className="text-lg font-display font-semibold">{name}</h2>
             <div className="text-sm text-neutral-500">
               {plant.species || "—"}
               {acquired && ` • Acquired ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(acquired)}`}

--- a/app/app/plants/page.tsx
+++ b/app/app/plants/page.tsx
@@ -25,7 +25,7 @@ export default function PlantsPage() {
     <section className="mt-4 space-y-6">
       <div>
         <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-medium text-neutral-600">My Plants</h2>
+          <h2 className="text-sm font-display font-medium text-neutral-600">My Plants</h2>
           <span className="text-xs text-neutral-500">
             {items?.length ?? 0} total
           </span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,14 @@ export default function RootLayout({
   return (
     // Avoid hydration mismatches when extensions add attributes to <html>
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Cabinet+Grotesk:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body className="min-h-screen bg-neutral-50 text-neutral-900">
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,2 +1,15 @@
-import Link from 'next/link'; export default function Home(){return <main className='min-h-[100dvh] grid place-items-center p-8'><div className='text-center space-y-4'><h1 className='text-2xl font-semibold'>Plant MVP (Mock Data)</h1><p>Open the app shell:</p><Link href='/app' className='underline'>Go to App</Link></div></main>;}
-import { use } from "react";
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main className="min-h-[100dvh] grid place-items-center p-8">
+      <div className="text-center space-y-4">
+        <h1 className="text-2xl font-display font-semibold">Plant MVP (Mock Data)</h1>
+        <p>Open the app shell:</p>
+        <Link href="/app" className="underline">
+          Go to App
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -22,7 +22,7 @@ export default function StyleGuidePreviewPage() {
       {/* Core Colors */}
       <Card>
         <CardContent className="p-6">
-          <h2 className="text-xl font-semibold mb-4">Core Tokens</h2>
+          <h2 className="text-xl font-display font-semibold mb-4">Core Tokens</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             <ColorSwatch name="Primary" hex="#508C7E" />
             <ColorSwatch name="Secondary" hex="#D3EDE6" />
@@ -36,7 +36,7 @@ export default function StyleGuidePreviewPage() {
       {/* Seasonal Themes */}
       <Card>
         <CardContent className="p-6 space-y-6">
-          <h2 className="text-xl font-semibold">Seasonal Themes</h2>
+          <h2 className="text-xl font-display font-semibold">Seasonal Themes</h2>
 
           <div>
             <h3 className="text-md font-medium mb-2">{previewMode === "light" ? "Light Mode" : "Dark Mode"}</h3>

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -139,7 +139,7 @@ export default function AddPlantModal({
       {/* panel */}
       <div className="relative w-full sm:max-w-lg bg-white rounded-t-2xl sm:rounded-2xl shadow-xl max-h-[90vh] overflow-y-auto">
         <div className="p-5 border-b">
-          <h2 className="text-lg font-semibold">Add Plant</h2>
+          <h2 className="text-lg font-display font-semibold">Add Plant</h2>
           <p className="text-sm text-neutral-600">Use a canned AI suggestion for MVP.</p>
         </div>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,7 +9,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        display: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+        display: ["Cabinet Grotesk", "ui-sans-serif", "system-ui", "sans-serif"],
         sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
       },
     },


### PR DESCRIPTION
## Summary
- load Cabinet Grotesk from Google Fonts and configure Tailwind `fontFamily.display`
- apply `font-display` to all heading components so they render with Cabinet Grotesk

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ccf5658832484b0e52575711251