### PR TITLE
feat: centralize design tokens

### DIFF
--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -3,6 +3,12 @@
 import { useState } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import {
+  coreColors,
+  seasonalLight,
+  seasonalDark,
+  type ThemeTokens,
+} from "@/lib/design-tokens"
 
 export default function StyleGuidePreviewPage() {
   const [previewMode, setPreviewMode] = useState<"light" | "dark">("light")
@@ -24,11 +30,11 @@ export default function StyleGuidePreviewPage() {
         <CardContent className="p-6">
           <h2 className="text-xl font-semibold mb-4">Core Tokens</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <ColorSwatch name="Primary" hex="#508C7E" />
-            <ColorSwatch name="Secondary" hex="#D3EDE6" />
-            <ColorSwatch name="Background" hex="#F9F9F9" text="black" />
-            <ColorSwatch name="Foreground" hex="#111827" />
-            <ColorSwatch name="Muted" hex="#9CA3AF" />
+            <ColorSwatch name="Primary" hex={coreColors.primary} />
+            <ColorSwatch name="Secondary" hex={coreColors.secondary} />
+            <ColorSwatch name="Background" hex={coreColors.background} text="black" />
+            <ColorSwatch name="Foreground" hex={coreColors.foreground} />
+            <ColorSwatch name="Muted" hex={coreColors.muted} />
           </div>
         </CardContent>
       </Card>
@@ -62,13 +68,18 @@ function ColorSwatch({ name, hex, text = "white" }: { name: string, hex: string,
   )
 }
 
-function ThemeSwatch({ label, primary, secondary, background, foreground }: ThemeProps) {
+function ThemeSwatch({ label, primary, secondary, background, foreground }: ThemeTokens) {
   return (
     <div className="rounded-lg border overflow-hidden text-xs shadow">
       <div className="flex h-6 text-[10px] text-center text-white font-bold">
         <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: primary }}>Primary</div>
         <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: secondary }}>Secondary</div>
-        <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: background, color: '#000' }}>BG</div>
+        <div
+          className="flex-1 flex items-center justify-center"
+          style={{ backgroundColor: background, color: coreColors.foreground }}
+        >
+          BG
+        </div>
         <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: foreground }}>FG</div>
       </div>
       <div className="p-2">
@@ -83,66 +94,3 @@ function ThemeSwatch({ label, primary, secondary, background, foreground }: Them
     </div>
   )
 }
-
-interface ThemeProps {
-  label: string
-  primary: string
-  secondary: string
-  background: string
-  foreground: string
-}
-
-const seasonalLight: ThemeProps[] = [
-  {
-    label: "Spring",
-    primary: "#6CA995",
-    secondary: "#E2F7F2",
-    background: "#FDFDFD",
-    foreground: "#1F2937"
-  },
-  {
-    label: "Summer (Default)",
-    primary: "#508C7E",
-    secondary: "#D3EDE6",
-    background: "#F9F9F9",
-    foreground: "#111827"
-  },
-  {
-    label: "Autumn",
-    primary: "#C38154",
-    secondary: "#F5E7DA",
-    background: "#FBFAF8",
-    foreground: "#3B2F2F"
-  },
-  {
-    label: "Winter",
-    primary: "#6B7280",
-    secondary: "#E0E7FF",
-    background: "#F8FAFC",
-    foreground: "#1E293B"
-  },
-]
-
-const seasonalDark: ThemeProps[] = [
-  {
-    label: "Default",
-    primary: "#7BD7C2",
-    secondary: "#1B2A2B",
-    background: "#0B0F10",
-    foreground: "#E5E7EB"
-  },
-  {
-    label: "Winter",
-    primary: "#6C82B3",
-    secondary: "#1C2431",
-    background: "#0A101A",
-    foreground: "#E2E8F0"
-  },
-  {
-    label: "Autumn",
-    primary: "#D69F7E",
-    secondary: "#2E1E1E",
-    background: "#1A1410",
-    foreground: "#F3F4F6"
-  }
-]

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,0 +1,71 @@
+export interface ThemeTokens {
+  label: string
+  primary: string
+  secondary: string
+  background: string
+  foreground: string
+}
+
+export const coreColors = {
+  primary: "#508C7E",
+  secondary: "#D3EDE6",
+  background: "#F9F9F9",
+  foreground: "#111827",
+  muted: "#9CA3AF",
+}
+
+export const seasonalLight: ThemeTokens[] = [
+  {
+    label: "Spring",
+    primary: "#6CA995",
+    secondary: "#E2F7F2",
+    background: "#FDFDFD",
+    foreground: "#1F2937",
+  },
+  {
+    label: "Summer (Default)",
+    primary: "#508C7E",
+    secondary: "#D3EDE6",
+    background: "#F9F9F9",
+    foreground: "#111827",
+  },
+  {
+    label: "Autumn",
+    primary: "#C38154",
+    secondary: "#F5E7DA",
+    background: "#FBFAF8",
+    foreground: "#3B2F2F",
+  },
+  {
+    label: "Winter",
+    primary: "#6B7280",
+    secondary: "#E0E7FF",
+    background: "#F8FAFC",
+    foreground: "#1E293B",
+  },
+]
+
+export const seasonalDark: ThemeTokens[] = [
+  {
+    label: "Default",
+    primary: "#7BD7C2",
+    secondary: "#1B2A2B",
+    background: "#0B0F10",
+    foreground: "#E5E7EB",
+  },
+  {
+    label: "Winter",
+    primary: "#6C82B3",
+    secondary: "#1C2431",
+    background: "#0A101A",
+    foreground: "#E2E8F0",
+  },
+  {
+    label: "Autumn",
+    primary: "#D69F7E",
+    secondary: "#2E1E1E",
+    background: "#1A1410",
+    foreground: "#F3F4F6",
+  },
+]
+


### PR DESCRIPTION
## Summary
- add `lib/design-tokens.ts` exporting core colors and seasonal theme palettes
- refactor style guide page to consume shared tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a25d5bc7ac832496fcf2dc0439afe6