### PR TITLE
feat: include seasonal context in AI care recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos
 - 📓 **Plant Notes** – Journal free-form entries from the plant detail view
 - 📊 **Quick Stats** – At-a-glance summary of watering, fertilizing, and environment needs
-- 📍 **Smart Care Suggestions** – Based on light, humidity, pot size, species, and weather
+- 📍 **Smart Care Suggestions** – Based on light, humidity, pot size, species, weather, and season
 - 💧 **ET₀‑Aware Watering** – Adjusts suggested watering intervals using local evapotranspiration data
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime
@@ -157,8 +157,10 @@ Request plant-specific care guidance powered by OpenAI:
 ```bash
 curl -X POST http://localhost:3000/api/ai/care-recommend \\
   -H 'Content-Type: application/json' \\
-  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium"}'
+  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium","season":"winter"}'
 ```
 
 This returns JSON with recommended `water`, `fertilizer`, `light`, and `repot` fields.
+
+Include the optional `season` field to tailor care advice to the time of year. If omitted, the current season is used.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,7 +98,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Soil type
   - [x] Indoor light level
   - [x] Room humidity
-  - [ ] Seasonal changes
+  - [x] Seasonal changes
   - [ ] Plant location (room/outdoor/etc.)
 - [ ] Learn from user input:
   - [ ] Feedback (e.g. “too much water”)

--- a/app/api/ai/care-recommend/route.ts
+++ b/app/api/ai/care-recommend/route.ts
@@ -3,6 +3,14 @@ import OpenAI from "openai";
 
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+function getSeason(date: Date = new Date()): string {
+  const month = date.getMonth() + 1;
+  if (month >= 3 && month <= 5) return "spring";
+  if (month >= 6 && month <= 8) return "summer";
+  if (month >= 9 && month <= 11) return "fall";
+  return "winter";
+}
+
 export async function POST(req: NextRequest) {
   if (!process.env.OPENAI_API_KEY) {
     return NextResponse.json(
@@ -18,6 +26,7 @@ export async function POST(req: NextRequest) {
   const soilType = body.soilType ?? "well-draining";
   const lightLevel = body.lightLevel ?? "medium";
   const humidity = body.humidity ?? "medium";
+  const season = body.season ?? getSeason();
 
   try {
     const completion = await client.chat.completions.create({
@@ -30,7 +39,7 @@ export async function POST(req: NextRequest) {
         },
           {
             role: "user",
-            content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
+            content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nSeason: ${season}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
           },
       ],
       response_format: { type: "json_object" },


### PR DESCRIPTION
## Summary
- consider current season when generating AI plant care suggestions
- document optional `season` field in AI recommendation API
- check off seasonal changes in roadmap

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a25cb9fd348324b1060fc78d1d169c