### PR TITLE
feat: include plant location in AI recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos
 - 📓 **Plant Notes** – Journal free-form entries from the plant detail view
 - 📊 **Quick Stats** – At-a-glance summary of watering, fertilizing, and environment needs
-- 📍 **Smart Care Suggestions** – Based on light, humidity, pot size, species, weather, and season
+- 📍 **Smart Care Suggestions** – Based on location, light, humidity, pot size, species, weather, and season
 - 💧 **ET₀‑Aware Watering** – Adjusts suggested watering intervals using local evapotranspiration data
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime
@@ -157,10 +157,10 @@ Request plant-specific care guidance powered by OpenAI:
 ```bash
 curl -X POST http://localhost:3000/api/ai/care-recommend \\
   -H 'Content-Type: application/json' \\
-  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium","season":"winter"}'
+  -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium","season":"winter","location":"living room"}'
 ```
 
 This returns JSON with recommended `water`, `fertilizer`, `light`, and `repot` fields.
 
-Include the optional `season` field to tailor care advice to the time of year. If omitted, the current season is used.
+Include the optional `season` and `location` fields to tailor care advice to the time of year and environment. If omitted, the current season is used and location defaults to `unspecified`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Indoor light level
   - [x] Room humidity
   - [x] Seasonal changes
-  - [ ] Plant location (room/outdoor/etc.)
+  - [x] Plant location (room/outdoor/etc.)
 - [ ] Learn from user input:
   - [ ] Feedback (e.g. “too much water”)
   - [ ] Adjust future care suggestions

--- a/app/api/ai/care-recommend/route.ts
+++ b/app/api/ai/care-recommend/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: NextRequest) {
   const lightLevel = body.lightLevel ?? "medium";
   const humidity = body.humidity ?? "medium";
   const season = body.season ?? getSeason();
+  const location = body.location ?? "unspecified";
 
   try {
     const completion = await client.chat.completions.create({
@@ -39,7 +40,7 @@ export async function POST(req: NextRequest) {
         },
           {
             role: "user",
-            content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nSeason: ${season}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
+              content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nSeason: ${season}\nLocation: ${location}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
           },
       ],
       response_format: { type: "json_object" },


### PR DESCRIPTION
## Summary
- allow `location` input in AI care recommendation API
- document new `location` field and example usage
- mark roadmap task for plant location input as complete

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a25eba016c8324adeadafa9b121fd2