### PR TITLE
feat(ai): refine care recommendations with feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,5 +162,18 @@ curl -X POST http://localhost:3000/api/ai/care-recommend \\
 
 This returns JSON with recommended `water`, `fertilizer`, `light`, and `repot` fields.
 
-Include the optional `season` and `location` fields to tailor care advice to the time of year and environment. If omitted, the current season is used and location defaults to `unspecified`.
+Include optional fields:
+
+- `season` and `location` to tailor care advice to the time of year and environment. If omitted, the current season is used and location defaults to `unspecified`.
+- `feedback` to tweak future recommendations based on previous guidance (e.g. `"too much water"`).
+
+Example with feedback:
+
+```bash
+curl -X POST http://localhost:3000/api/ai/care-recommend \\
+  -H 'Content-Type: application/json' \\
+  -d '{"species":"Monstera deliciosa","feedback":"too much water"}'
+```
+
+The feedback is included in the AI prompt so new suggestions are adjusted accordingly.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,7 +92,7 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Fertilizer type and frequency
   - [x] Light level requirements
   - [x] Repotting schedule
-- [ ] Input factors for recommendations:
+- [x] Input factors for recommendations:
   - [x] Pot size
   - [x] Pot material
   - [x] Soil type
@@ -100,9 +100,9 @@ All items are **unchecked** to indicate upcoming work.
   - [x] Room humidity
   - [x] Seasonal changes
   - [x] Plant location (room/outdoor/etc.)
-- [ ] Learn from user input:
-  - [ ] Feedback (e.g. “too much water”)
-  - [ ] Adjust future care suggestions
+- [x] Learn from user input:
+  - [x] Feedback (e.g. “too much water”)
+  - [x] Adjust future care suggestions
 - [ ] Long-term idea: fine-tune a model using user care logs
 
 ---

--- a/app/api/ai/care-recommend/route.ts
+++ b/app/api/ai/care-recommend/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
   const humidity = body.humidity ?? "medium";
   const season = body.season ?? getSeason();
   const location = body.location ?? "unspecified";
+  const feedback = body.feedback ?? "";
 
   try {
     const completion = await client.chat.completions.create({
@@ -38,10 +39,10 @@ export async function POST(req: NextRequest) {
           content:
             "You are a helpful plant care assistant that replies in JSON.",
         },
-          {
-            role: "user",
-              content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nSeason: ${season}\nLocation: ${location}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
-          },
+        {
+          role: "user",
+          content: `Give care recommendations for a plant with the following details:\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}\nSoil type: ${soilType}\nLight level: ${lightLevel}\nHumidity: ${humidity}\nSeason: ${season}\nLocation: ${location}${feedback ? `\nUser feedback on previous advice: ${feedback}` : ""}\nRespond with a JSON object containing water (amountMl, frequencyDays), fertilizer (type, frequencyDays), light (level), repot (schedule).`,
+        },
       ],
       response_format: { type: "json_object" },
     });


### PR DESCRIPTION
## Summary
- allow `/api/ai/care-recommend` to accept user feedback and include it in the AI prompt
- document feedback usage in README
- update roadmap with completed AI learning tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: OPENAI_API_KEY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a260241c988324a46f666c7ccf20b8