### PR TITLE
feat: add theme preview toggle

### DIFF
--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -14,12 +14,13 @@ export default function StyleGuidePreviewPage() {
   const [previewMode, setPreviewMode] = useState<"light" | "dark">("light")
 
   return (
-    <div className="p-6 space-y-8">
-      <div className="flex justify-between items-center">
-        <h1 className="text-4xl font-display">Style Guide</h1>
-        <Button
-          variant="secondary"
-          onClick={() => setPreviewMode(previewMode === "light" ? "dark" : "light")}
+    <div data-theme={previewMode} className={previewMode === "dark" ? "dark" : ""}>
+      <div className="min-h-screen p-6 space-y-8 bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 transition-colors">
+        <div className="flex justify-between items-center">
+          <h1 className="text-4xl font-display">Style Guide</h1>
+          <Button
+            variant="secondary"
+            onClick={() => setPreviewMode(previewMode === "light" ? "dark" : "light")}
         >
           Preview: {previewMode === "light" ? "Light" : "Dark"}
         </Button>
@@ -54,6 +55,7 @@ export default function StyleGuidePreviewPage() {
           </div>
         </CardContent>
       </Card>
+      </div>
     </div>
   )
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -14,13 +14,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
   ref
 ) {
   const base =
-    "inline-flex items-center justify-center rounded-xl font-medium outline-none transition focus-visible:ring-2 focus-visible:ring-neutral-400 disabled:opacity-50 disabled:pointer-events-none";
+    "inline-flex items-center justify-center rounded-xl font-medium outline-none transition focus-visible:ring-2 focus-visible:ring-neutral-400 dark:focus-visible:ring-neutral-600 disabled:opacity-50 disabled:pointer-events-none";
   const byVariant =
     variant === "secondary"
-      ? "bg-neutral-100 text-neutral-900 hover:bg-neutral-200"
+      ? "bg-neutral-100 text-neutral-900 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
       : variant === "ghost"
-      ? "bg-transparent text-neutral-900 hover:bg-neutral-100"
-      : "bg-neutral-900 text-white hover:bg-neutral-800";
+      ? "bg-transparent text-neutral-900 hover:bg-neutral-100 dark:text-neutral-100 dark:hover:bg-neutral-800"
+      : "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200";
   const bySize =
     size === "sm" ? "h-8 px-3 text-sm" : size === "icon" ? "h-10 w-10 p-0" : "h-10 px-4";
   return <button ref={ref} className={`${base} ${byVariant} ${bySize} ${className}`} {...props} />;

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -6,7 +6,12 @@ type HProps = React.HTMLAttributes<HTMLHeadingElement>;
 type PProps = React.HTMLAttributes<HTMLParagraphElement>;
 
 export function Card({ className = "", ...props }: DivProps) {
-  return <div className={`rounded-xl border bg-white shadow-sm ${className}`} {...props} />;
+  return (
+    <div
+      className={`rounded-xl border bg-white shadow-sm dark:bg-neutral-800 dark:border-neutral-700 ${className}`}
+      {...props}
+    />
+  );
 }
 export function CardHeader({ className = "", ...props }: DivProps) {
   return <div className={`p-4 ${className}`} {...props} />;
@@ -15,7 +20,9 @@ export function CardTitle({ className = "", ...props }: HProps) {
   return <h3 className={`text-base font-medium ${className}`} {...props} />;
 }
 export function CardDescription({ className = "", ...props }: PProps) {
-  return <p className={`text-sm text-neutral-500 ${className}`} {...props} />;
+  return (
+    <p className={`text-sm text-neutral-500 dark:text-neutral-400 ${className}`} {...props} />
+  );
 }
 export function CardContent({ className = "", ...props }: DivProps) {
   return <div className={`p-4 ${className}`} {...props} />;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- wrap style guide content in theme container toggled by preview mode
- enable Tailwind dark mode and add dark styling for card and button components

## Testing
- `npm test` *(fails: Missing script)*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25f0d088c832480b8369e999d7bbc