### PR TITLE
feat: add timeline event filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals
 - 📜 **Global Timeline** – View all plant care events in a chronological feed
 - 🔁 **Timeline Task Actions** – Complete tasks directly from the timeline with undo support
+- 🔍 **Timeline Filters** – Narrow the timeline by event type (water, fertilize, repot)
 - 📸 **Photo Gallery** – View plant photos over time to track growth
 - 🌿 **Plant Detail Hero** – Large photo banner with species and acquisition date
 - 🧭 **Tabbed Plant Details** – Switch between stats, timeline, notes, and photos

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,7 +110,7 @@ All items are **unchecked** to indicate upcoming work.
 ## Phase 3 – Journaling & History
 
 - [x] Timeline view of all plant care events
-- [ ] Filter by event type (water, fertilize, etc.)
+- [x] Filter by event type (water, fertilize, etc.)
 - [ ] Add plant photo journal entries
 - [ ] Mood/notes tagging per entry
 

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -119,6 +119,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
   const [events, setEvents] = useState<EventDTO[]>([]);
   const [eventsErr, setEventsErr] = useState<string | null>(null);
   const [eventsLoading, setEventsLoading] = useState(false);
+  const [eventTypeFilter, setEventTypeFilter] = useState("");
 
   // plants list for Plants tab
   const [plants, setPlants] = useState<PlantListItem[]>([]);
@@ -157,6 +158,12 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
       );
     });
   }, [tasks, roomFilter, typeFilter, statusFilter]);
+
+  const filteredEvents = useMemo(() => {
+    return eventTypeFilter
+      ? events.filter((e) => e.type === eventTypeFilter)
+      : events;
+  }, [events, eventTypeFilter]);
 
   async function refresh() {
     setLoading(true);
@@ -621,16 +628,28 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
               <div className="text-base font-medium">Timeline</div>
               <div className="text-xs text-neutral-500">Recent care events</div>
             </div>
+            <div className="px-4 py-2 border-b">
+              <select
+                value={eventTypeFilter}
+                onChange={(e) => setEventTypeFilter(e.target.value)}
+                className="border rounded px-3 py-2 w-full"
+              >
+                <option value="">All event types</option>
+                <option value="water">Water</option>
+                <option value="fertilize">Fertilize</option>
+                <option value="repot">Repot</option>
+              </select>
+            </div>
             <ul className="text-sm px-4 py-2">
               {eventsErr && <li className="py-3 text-red-600">{eventsErr}</li>}
               {!eventsErr && eventsLoading && (
                 <li className="py-3 text-neutral-500">Loading…</li>
               )}
-              {!eventsErr && !eventsLoading && events.length === 0 && (
+              {!eventsErr && !eventsLoading && filteredEvents.length === 0 && (
                 <li className="py-3 text-neutral-500">No events</li>
               )}
               {!eventsErr &&
-                events.map((e) => (
+                filteredEvents.map((e) => (
                   <li key={e.id} className="py-3 border-b last:border-b-0">
                     <span className="font-medium">{e.plantName}</span> — {pastTenseLabel(e.type)}
                     <span className="text-neutral-500"> {timeAgo(new Date(e.at))}</span>


### PR DESCRIPTION
## Summary
- allow filtering timeline events by type
- document timeline filters in README
- mark roadmap item as complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a263131f108324b2b9cb0283847e5e