### PR TITLE
Improve dark mode seasonal palettes and style guide previews

### DIFF
--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -10,6 +10,31 @@ import {
   type ThemeTokens,
 } from "@/lib/design-tokens"
 
+function hexToRgb(hex: string) {
+  const cleaned = hex.replace("#", "")
+  const bigint = parseInt(cleaned.length === 3 ? cleaned.repeat(2) : cleaned, 16)
+  return [bigint >> 16 & 255, bigint >> 8 & 255, bigint & 255]
+}
+
+function luminance(hex: string) {
+  const [r, g, b] = hexToRgb(hex).map((v) => {
+    const channel = v / 255
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrastRatio(a: string, b: string) {
+  const L1 = luminance(a)
+  const L2 = luminance(b)
+  return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05)
+}
+
+function adjustColor(hex: string, amount: number) {
+  const [r, g, b] = hexToRgb(hex).map((v) => Math.max(0, Math.min(255, v + amount)))
+  return `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`
+}
+
 export default function StyleGuidePreviewPage() {
   const [previewMode, setPreviewMode] = useState<"light" | "dark">("light")
 
@@ -78,6 +103,14 @@ function ColorSwatch({ name, hex, text = "white" }: { name: string, hex: string,
 }
 
 function ThemeSwatch({ label, primary, secondary, background, foreground }: ThemeTokens) {
+  const contrastChecks = [
+    { label: "FG/BG", ratio: contrastRatio(foreground, background) },
+    { label: "Primary/BG", ratio: contrastRatio(primary, background) },
+    { label: "Secondary/BG", ratio: contrastRatio(secondary, background) },
+  ]
+  const hover = adjustColor(primary, 20)
+  const active = adjustColor(primary, -20)
+
   return (
     <div className="rounded-lg border overflow-hidden text-xs shadow">
       <div className="flex h-6 text-[10px] text-center text-white font-bold">
@@ -114,14 +147,44 @@ function ThemeSwatch({ label, primary, secondary, background, foreground }: Them
           FG
         </div>
       </div>
-      <div className="p-2">
-        <strong className="block text-sm mb-1">{label}</strong>
+      <div className="p-2 space-y-2">
+        <strong className="block text-sm">{label}</strong>
         <ul className="space-y-1">
           <li><span className="font-medium">Primary:</span> {primary}</li>
           <li><span className="font-medium">Secondary:</span> {secondary}</li>
           <li><span className="font-medium">Background:</span> {background}</li>
           <li><span className="font-medium">Foreground:</span> {foreground}</li>
         </ul>
+        <ul className="space-y-1">
+          {contrastChecks.map((c) => (
+            <li key={c.label}>
+              {c.label}: {c.ratio.toFixed(2)} {c.ratio >= 4.5 ? "✅" : "⚠️"}
+            </li>
+          ))}
+        </ul>
+        <div
+          className="rounded p-2 space-y-2"
+          style={{ backgroundColor: background, color: foreground }}
+        >
+          <p>Example card</p>
+          <button
+            className="px-2 py-1 rounded text-xs font-medium"
+            style={{ backgroundColor: primary, color: foreground }}
+          >
+            Button
+          </button>
+        </div>
+        <div className="flex h-6 text-[10px] text-center text-white font-bold rounded overflow-hidden">
+          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: primary }}>
+            Default
+          </div>
+          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: hover }}>
+            Hover
+          </div>
+          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: active }}>
+            Active
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -49,23 +49,23 @@ export const seasonalDark: ThemeTokens[] = [
   {
     label: "Default",
     primary: "#7BD7C2",
-    secondary: "#1B2A2B",
-    background: "#0B0F10",
+    secondary: "#1CA2B3",
+    background: "#0A0D0E",
     foreground: "#E5E7EB",
   },
   {
     label: "Winter",
-    primary: "#6C82B3",
-    secondary: "#1C2431",
+    primary: "#6D83C4",
+    secondary: "#98A9C5",
     background: "#0A101A",
     foreground: "#E2E8F0",
   },
   {
     label: "Autumn",
-    primary: "#D69F7E",
-    secondary: "#2E1E1E",
+    primary: "#E09567",
+    secondary: "#3A2B2B",
     background: "#1A1410",
-    foreground: "#F3F4F6",
+    foreground: "#F8F8F8",
   },
 ]
 


### PR DESCRIPTION
## Summary
- Refresh dark mode seasonal palettes with higher contrast colors
- Add contrast ratios, example components, and interaction state previews to style guide

## Testing
- `npm test` *(fails: Missing script)*
- `OPENAI_API_KEY=dummy npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a2656886788324abbb8934b82bc1ec