### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 📊 **Visual Insights** – See patterns like ET₀ vs care frequency
 - 📦 **Import/Export Tools** – Backup your plant journal anytime
 - 📱 **Mobile-First Layout** – Bottom navigation, floating action button, and swipeable task cards optimized for one-handed use
+- 🌗 **Light/Dark Mode** – Toggle the interface theme from Settings
 - 🌤️ **Weather Awareness** – Current local weather for each plant using Open‑Meteo
 - 🔔 **Condition Alerts** – Notifies you when weather suggests watering or fertilizing soon
 - 🤖 **AI Care Recommendations** – Generates plant-specific watering, fertilizer, light, and repotting guidance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,10 +118,10 @@ All items are **unchecked** to indicate upcoming work.
 
 ## Phase 4 – App Polish
 
-- [ ] Bottom nav and floating FAB
+- [x] Bottom nav and floating FAB
 - [ ] Swipeable task actions (mark done, edit, delete)
 
-- [ ] Light/dark mode toggle in settings
+- [x] Light/dark mode toggle in settings
 - [ ] Mobile UX refinements
 
 - [ ] Align design with [Style Guide](./style-guide/page.tsx)

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -8,6 +8,7 @@ import TaskRow from "@/components/TaskRow";
 import QuickAddModal from "@/components/QuickAddModal";
 import AddPlantModal from "@/components/AddPlantModal";
 import EditTaskModal from "@/components/EditTaskModal";
+import ThemeToggle from "@/components/ThemeToggle";
 import { TaskDTO } from "@/lib/types";
 import { motion } from "framer-motion";
 import { Check } from "lucide-react";
@@ -735,9 +736,9 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
 
         {view === "settings" && (
           <section className="mt-4 grid gap-3">
-            <div className="rounded-xl border bg-white shadow-sm p-4">
+            <div className="rounded-xl border bg-white shadow-sm p-4 dark:bg-neutral-800 dark:border-neutral-700">
               <div className="text-base font-medium">Export / Import</div>
-              <div className="text-sm text-neutral-600">
+              <div className="text-sm text-neutral-600 dark:text-neutral-300">
                 Backup JSON / CSV; restore from file
               </div>
               <div className="mt-2 flex gap-2">
@@ -747,10 +748,14 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
                 <button className="border rounded px-3 py-2 text-sm">
                   Export CSV
                 </button>
-                <button className="bg-neutral-900 text-white rounded px-3 py-2 text-sm">
+                <button className="bg-neutral-900 text-white rounded px-3 py-2 text-sm dark:bg-neutral-100 dark:text-neutral-900">
                   Import
                 </button>
               </div>
+            </div>
+            <div className="rounded-xl border bg-white shadow-sm p-4 flex items-center justify-between dark:bg-neutral-800 dark:border-neutral-700">
+              <div className="text-base font-medium">Theme</div>
+              <ThemeToggle />
             </div>
           </section>
         )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-body{@apply bg-neutral-50 text-neutral-900;}
+body{@apply bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50;}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="min-h-screen bg-neutral-50 text-neutral-900">
+      <body className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50">
         {children}
       </body>
     </html>

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -27,20 +27,24 @@ export default function BottomNav({
       <button
         onClick={() => onChange(tab)}
         className={`py-3 flex flex-col items-center justify-center text-xs ${
-          active ? "text-neutral-900" : "text-neutral-600"
+          active
+            ? "text-neutral-900 dark:text-neutral-100"
+            : "text-neutral-600 dark:text-neutral-400"
         }`}
         aria-current={active ? "page" : undefined}
       >
         <div className={`mb-1 ${active ? "" : "opacity-80"}`}>{icon}</div>
         <span className="font-sans">{label}</span>
-        {active && <span className="mt-1 h-1 w-6 rounded-full bg-neutral-900" />}
+        {active && (
+          <span className="mt-1 h-1 w-6 rounded-full bg-neutral-900 dark:bg-neutral-100" />
+        )}
       </button>
     );
   };
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t"
+      className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t dark:bg-neutral-900/90 dark:border-neutral-800"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="max-w-screen-sm mx-auto grid grid-cols-5">

--- a/components/Fab.tsx
+++ b/components/Fab.tsx
@@ -7,7 +7,7 @@ export default function Fab({ onClick }: { onClick: () => void }) {
     <button
       onClick={onClick}
       aria-label="Add"
-      className="fixed right-4 h-12 w-12 rounded-full bg-neutral-900 text-white grid place-items-center shadow-lg"
+      className="fixed right-4 h-12 w-12 rounded-full bg-neutral-900 text-white grid place-items-center shadow-lg dark:bg-neutral-100 dark:text-neutral-900"
       style={{ bottom: `calc(5rem + env(safe-area-inset-bottom))` }}
     >
       <Plus className="h-5 w-5" />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("theme") : null;
+    const isDark = stored === "dark";
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+  }, []);
+
+  function toggle() {
+    const isDark = !dark;
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+    if (isDark) {
+      localStorage.setItem("theme", "dark");
+    } else {
+      localStorage.setItem("theme", "light");
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className="border rounded px-3 py-2 text-sm" >
+      {dark ? "Light Mode" : "Dark Mode"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeToggle to persist light/dark mode preference
- wire toggle into settings view and style core components for dark theme
- document dark mode feature and mark roadmap item complete

## Testing
- `npm test` (fails: Missing script)
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2663fdcec8324abf0caf560a18269