### PR TITLE
feat: add swipeable task actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - ⏰ **Overdue/Urgent Filters** – Show only overdue tasks or those due soon
 - 📝 **Quick Notes** – Jot down observations directly from any task card
 - ✅ **Inline Task Actions** – Mark tasks done, defer them, or edit details without leaving the dashboard
+- 👉 **Swipe Actions** – Swipe a task to quickly complete, edit, or delete it
 - 🎉 **Completion Feedback** – Subtle check animation and timestamp confirmation when tasks are marked done
 - 🪴 **Room-Based Organization** – Organize plants by room with photo galleries
 - 🧪 **Care Defaults** – Onboard new plants with preset watering and fertilizing intervals

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,7 @@ All items are **unchecked** to indicate upcoming work.
 ## Phase 4 – App Polish
 
 - [x] Bottom nav and floating FAB
-- [ ] Swipeable task actions (mark done, edit, delete)
+ - [x] Swipeable task actions (mark done, edit, delete)
 
 - [x] Light/dark mode toggle in settings
 - [ ] Mobile UX refinements

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -52,26 +52,35 @@ export default function TaskRow({
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl overflow-hidden">
-        <div className="absolute inset-y-0 left-0 w-1/2 grid place-items-center bg-emerald-100 text-emerald-700">
+        <div className="absolute inset-y-0 left-0 w-20 grid place-items-center bg-emerald-100 text-emerald-700">
           <div className="flex items-center gap-2 text-xs font-medium">
             <Check className="h-4 w-4" />
             Complete
           </div>
         </div>
-        <div className="absolute inset-y-0 right-0 w-1/2 grid place-items-center bg-red-100 text-red-600">
-          <div className="flex items-center gap-2 text-xs font-medium">
-            <Trash2 className="h-4 w-4" />
-            Delete
+        <div className="absolute inset-y-0 right-0 flex">
+          <div className="w-20 grid place-items-center bg-blue-100 text-blue-600">
+            <div className="flex items-center gap-2 text-xs font-medium">
+              <Edit2 className="h-4 w-4" />
+              Edit
+            </div>
+          </div>
+          <div className="w-20 grid place-items-center bg-red-100 text-red-600">
+            <div className="flex items-center gap-2 text-xs font-medium">
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </div>
           </div>
         </div>
       </div>
       <motion.div
         drag="x"
-        dragConstraints={{ left: -120, right: 120 }}
+        dragConstraints={{ left: -160, right: 80 }}
         dragElastic={0.2}
         onDragEnd={(_, i) => {
-          if (i.offset.x > 80) onComplete();
-          else if (i.offset.x < -80) onDelete();
+          if (i.offset.x > 60) onComplete();
+          else if (i.offset.x < -120) onDelete();
+          else if (i.offset.x < -60) onEdit();
         }}
         className="relative"
       >


### PR DESCRIPTION
## Summary
- add left/right swipe zones for completing, editing, or deleting a task
- document swipe actions and mark roadmap item complete

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: OPENAI_API_KEY env var missing)


------
https://chatgpt.com/codex/tasks/task_e_68a2689698088324934eace852f90a2a