### PR TITLE
feat: add CSV export endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Example:
 curl -X PATCH http://localhost:3000/api/tasks/t_<uuid>
 ```
 
+## 📦 Import/Export API
+
+Backup or restore tasks using these endpoints:
+
+- `GET /api/export` – download tasks as JSON
+- `GET /api/export?format=csv` – download tasks as CSV
+- `POST /api/import` – replace tasks with `{ "tasks": Task[] }`
+
 ## 🤖 AI Recommendation API
 
 Request plant-specific care guidance powered by OpenAI:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,7 +132,7 @@ All items are **unchecked** to indicate upcoming work.
 
 ## Phase 5 – Data Import/Export
 
-- [ ] Export plant data to JSON or `.csv`
+- [x] Export plant data to JSON or `.csv`
 - [ ] Import plant data from previous backups
 - [ ] Sync across devices via Supabase Auth
 

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,6 +1,35 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { dump } from "@/lib/mockdb";
 
-export async function GET() {
-  return NextResponse.json({ tasks: dump() }, { headers: { "Cache-Control": "no-store" } });
+export async function GET(req: NextRequest) {
+  const format = req.nextUrl.searchParams.get("format");
+  const tasks = dump();
+
+  if (format === "csv") {
+    const header = "id,plantId,plantName,roomId,type,dueAt,status,lastEventAt";
+    const rows = tasks.map(t =>
+      [
+        t.id,
+        t.plantId,
+        t.plantName,
+        t.roomId,
+        t.type,
+        t.dueAt,
+        t.status,
+        t.lastEventAt ?? "",
+      ].join(","),
+    );
+
+    return new NextResponse([header, ...rows].join("\n"), {
+      headers: {
+        "Content-Type": "text/csv",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  return NextResponse.json(
+    { tasks },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }


### PR DESCRIPTION
## Summary
- add CSV format option to `/api/export`
- document import/export API
- update roadmap for export feature

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: The OPENAI_API_KEY environment variable is missing or empty)

------
https://chatgpt.com/codex/tasks/task_e_68a269b2f77483249f4d3b84d38bc422