### PR TITLE
chore: remove seasonal themes

### DIFF
--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -3,37 +3,7 @@
 import { useState } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import {
-  coreColors,
-  seasonalLight,
-  seasonalDark,
-  type ThemeTokens,
-} from "@/lib/design-tokens"
-
-function hexToRgb(hex: string) {
-  const cleaned = hex.replace("#", "")
-  const bigint = parseInt(cleaned.length === 3 ? cleaned.repeat(2) : cleaned, 16)
-  return [bigint >> 16 & 255, bigint >> 8 & 255, bigint & 255]
-}
-
-function luminance(hex: string) {
-  const [r, g, b] = hexToRgb(hex).map((v) => {
-    const channel = v / 255
-    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)
-  })
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b
-}
-
-function contrastRatio(a: string, b: string) {
-  const L1 = luminance(a)
-  const L2 = luminance(b)
-  return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05)
-}
-
-function adjustColor(hex: string, amount: number) {
-  const [r, g, b] = hexToRgb(hex).map((v) => Math.max(0, Math.min(255, v + amount)))
-  return `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`
-}
+import { coreColors } from "@/lib/design-tokens"
 
 export default function StyleGuidePreviewPage() {
   const [previewMode, setPreviewMode] = useState<"light" | "dark">("light")
@@ -54,8 +24,7 @@ export default function StyleGuidePreviewPage() {
         </Button>
       </div>
       <p className="text-sm text-muted-foreground">
-        Toggle the preview to inspect light or dark tokens. Expand any seasonal theme to see detailed values,
-        contrast ratios, and component examples.
+        Toggle the preview to inspect light or dark tokens.
       </p>
 
       {/* Core Colors */}
@@ -72,21 +41,6 @@ export default function StyleGuidePreviewPage() {
         </CardContent>
       </Card>
 
-      {/* Seasonal Themes */}
-      <Card>
-        <CardContent className="p-6 space-y-6">
-          <h2 className="text-xl font-display font-semibold">Seasonal Themes</h2>
-
-          <div>
-            <h3 className="text-md font-medium mb-2">{previewMode === "light" ? "Light Mode" : "Dark Mode"}</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {(previewMode === "light" ? seasonalLight : seasonalDark).map((theme) => (
-                <ThemeSwatch key={theme.label} {...theme} />
-              ))}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }
@@ -103,103 +57,5 @@ function ColorSwatch({ name, hex, text = "white" }: { name: string, hex: string,
       <span className="text-sm text-muted-foreground">{name}</span>
       <span className="text-xs" style={{ color: text }}>{hex}</span>
     </div>
-  )
-}
-
-function ThemeSwatch({ label, primary, secondary, background, foreground }: ThemeTokens) {
-  const contrastChecks = [
-    { label: "FG/BG", ratio: contrastRatio(foreground, background) },
-    { label: "Primary/BG", ratio: contrastRatio(primary, background) },
-    { label: "Secondary/BG", ratio: contrastRatio(secondary, background) },
-  ]
-  const hover = adjustColor(primary, 20)
-  const active = adjustColor(primary, -20)
-
-  return (
-    <details className="rounded-lg border text-xs shadow" role="group">
-      <summary className="cursor-pointer list-none">
-        <div className="p-2 space-y-1">
-          <div className="flex h-6 text-[10px] text-center text-white font-bold rounded overflow-hidden">
-            <div
-              className="flex-1 flex items-center justify-center"
-              style={{ backgroundColor: primary }}
-              role="img"
-              aria-label={`Primary color swatch ${primary}`}
-            >
-              Primary
-            </div>
-            <div
-              className="flex-1 flex items-center justify-center"
-              style={{ backgroundColor: secondary }}
-              role="img"
-              aria-label={`Secondary color swatch ${secondary}`}
-            >
-              Secondary
-            </div>
-            <div
-              className="flex-1 flex items-center justify-center"
-              style={{ backgroundColor: background, color: coreColors.foreground }}
-              role="img"
-              aria-label={`Background color swatch ${background}`}
-            >
-              BG
-            </div>
-            <div
-              className="flex-1 flex items-center justify-center"
-              style={{ backgroundColor: foreground }}
-              role="img"
-              aria-label={`Foreground color swatch ${foreground}`}
-            >
-              FG
-            </div>
-          </div>
-          <span className="block text-sm font-medium">{label}</span>
-        </div>
-
-      </summary>
-      <div className="p-2 space-y-2 border-t" aria-label={`${label} theme details`}>
-
-      </div>
-      <div className="p-2 space-y-2">
-        <strong className="block text-sm">{label}</strong>
-
-        <ul className="space-y-1">
-          <li><span className="font-medium">Primary:</span> {primary}</li>
-          <li><span className="font-medium">Secondary:</span> {secondary}</li>
-          <li><span className="font-medium">Background:</span> {background}</li>
-          <li><span className="font-medium">Foreground:</span> {foreground}</li>
-        </ul>
-        <ul className="space-y-1">
-          {contrastChecks.map((c) => (
-            <li key={c.label}>
-              {c.label}: {c.ratio.toFixed(2)} {c.ratio >= 4.5 ? "✅" : "⚠️"}
-            </li>
-          ))}
-        </ul>
-        <div
-          className="rounded p-2 space-y-2"
-          style={{ backgroundColor: background, color: foreground }}
-        >
-          <p>Example card</p>
-          <button
-            className="px-2 py-1 rounded text-xs font-medium"
-            style={{ backgroundColor: primary, color: foreground }}
-          >
-            Button
-          </button>
-        </div>
-        <div className="flex h-6 text-[10px] text-center text-white font-bold rounded overflow-hidden">
-          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: primary }}>
-            Default
-          </div>
-          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: hover }}>
-            Hover
-          </div>
-          <div className="flex-1 flex items-center justify-center" style={{ backgroundColor: active }}>
-            Active
-          </div>
-        </div>
-      </div>
-    </details>
   )
 }

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,11 +1,3 @@
-export interface ThemeTokens {
-  label: string
-  primary: string
-  secondary: string
-  background: string
-  foreground: string
-}
-
 export const coreColors = {
   primary: "#508C7E",
   secondary: "#D3EDE6",
@@ -13,59 +5,4 @@ export const coreColors = {
   foreground: "#111827",
   muted: "#9CA3AF",
 }
-
-export const seasonalLight: ThemeTokens[] = [
-  {
-    label: "Spring",
-    primary: "#6CA995",
-    secondary: "#E2F7F2",
-    background: "#FDFDFD",
-    foreground: "#1F2937",
-  },
-  {
-    label: "Summer (Default)",
-    primary: "#508C7E",
-    secondary: "#D3EDE6",
-    background: "#F9F9F9",
-    foreground: "#111827",
-  },
-  {
-    label: "Autumn",
-    primary: "#C38154",
-    secondary: "#F5E7DA",
-    background: "#FBFAF8",
-    foreground: "#3B2F2F",
-  },
-  {
-    label: "Winter",
-    primary: "#6B7280",
-    secondary: "#E0E7FF",
-    background: "#F8FAFC",
-    foreground: "#1E293B",
-  },
-]
-
-export const seasonalDark: ThemeTokens[] = [
-  {
-    label: "Default",
-    primary: "#7BD7C2",
-    secondary: "#1CA2B3",
-    background: "#0A0D0E",
-    foreground: "#E5E7EB",
-  },
-  {
-    label: "Winter",
-    primary: "#6D83C4",
-    secondary: "#98A9C5",
-    background: "#0A101A",
-    foreground: "#E2E8F0",
-  },
-  {
-    label: "Autumn",
-    primary: "#E09567",
-    secondary: "#3A2B2B",
-    background: "#1A1410",
-    foreground: "#F8F8F8",
-  },
-]
 


### PR DESCRIPTION
## Summary
- remove seasonal theme section from style guide
- drop unused seasonal theme tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a26a6470948324b27084cff28802a6