### PR TITLE
feat: add plant import capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ curl -X PATCH http://localhost:3000/api/tasks/t_<uuid>
 
 ## 📦 Import/Export API
 
-Backup or restore tasks using these endpoints:
+Backup or restore plants and tasks using these endpoints:
 
-- `GET /api/export` – download tasks as JSON
+- `GET /api/export` – download a JSON payload with `{ plants, tasks }`
 - `GET /api/export?format=csv` – download tasks as CSV
-- `POST /api/import` – replace tasks with `{ "tasks": Task[] }`
+- `POST /api/import` – replace data with `{ "plants": Plant[], "tasks": Task[] }` (either field optional)
 
 ## 🤖 AI Recommendation API
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ All items are **unchecked** to indicate upcoming work.
 ## Phase 5 – Data Import/Export
 
 - [x] Export plant data to JSON or `.csv`
-- [ ] Import plant data from previous backups
+- [x] Import plant data from previous backups
 - [ ] Sync across devices via Supabase Auth
 
 ---

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -3,7 +3,7 @@ import { dump } from "@/lib/mockdb";
 
 export async function GET(req: NextRequest) {
   const format = req.nextUrl.searchParams.get("format");
-  const tasks = dump();
+  const { tasks, plants } = dump();
 
   if (format === "csv") {
     const header = "id,plantId,plantName,roomId,type,dueAt,status,lastEventAt";
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json(
-    { tasks },
+    { plants, tasks },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -3,9 +3,15 @@ import { load } from "@/lib/mockdb";
 
 export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => null);
-  if (!body || !Array.isArray(body.tasks)) {
-    return NextResponse.json({ error: "Invalid payload. Expected { tasks: Task[] }" }, { status: 400 });
+  if (
+    !body ||
+    (!Array.isArray(body.tasks) && !Array.isArray(body.plants))
+  ) {
+    return NextResponse.json(
+      { error: "Invalid payload. Expected { tasks?: Task[], plants?: Plant[] }" },
+      { status: 400 },
+    );
   }
-  const count = load(body.tasks);
-  return NextResponse.json({ ok: true, count });
+  const counts = load(body);
+  return NextResponse.json({ ok: true, ...counts });
 }

--- a/lib/mockdb.ts
+++ b/lib/mockdb.ts
@@ -387,12 +387,20 @@ export async function getPlants() {
 }
 
 export function dump() {
-  return TASKS.slice();
+  return {
+    plants: PLANTS.slice(),
+    tasks: TASKS.slice(),
+  };
 }
 
-export function load(tasks: TaskRec[] = []) {
-  TASKS = tasks.slice();
-  return TASKS.length;
+export function load(data: { plants?: Plant[]; tasks?: TaskRec[] } = {}) {
+  if (data.plants) {
+    PLANTS = data.plants.slice();
+  }
+  if (data.tasks) {
+    TASKS = data.tasks.slice();
+  }
+  return { plantCount: PLANTS.length, taskCount: TASKS.length };
 }
 
 export function getInsights() {


### PR DESCRIPTION
## Summary
- support exporting and importing both plants and tasks
- document import/export format and mark roadmap step complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a26d281e788324b05a414acc98c9c3