### PR TITLE
docs: add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ To create a production build run:
 npm run build
 ```
 
+## 🚀 Usage
+
+Once the development server is running:
+
+1. Visit [`/app`](http://localhost:3000/app) to see the task dashboard for today.
+2. Use the **+** button to add a new plant with care defaults.
+3. Tap a plant card to view its quick stats, timeline, notes, or photo gallery.
+4. Swipe a task to complete it, edit the details, or delete it.
+5. Use the room and task-type filters to focus on what's relevant.
+
 # 🌱 Kay Maria
 
 **Tend to what matters.**  

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@ All items are **unchecked** to indicate upcoming work.
 
 - [ ] Review accessibility
 - [ ] Lighthouse performance pass
-- [ ] Add `README.md` with usage instructions
+- [x] Add `README.md` with usage instructions
 - [ ] Create short demo video or gif
 - [ ] Deploy to Vercel and connect to custom domain
 - [ ] Manual test cases (mobile + desktop)


### PR DESCRIPTION
## Summary
- document basic app usage in README
- mark roadmap item for usage docs as complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: OPENAI_API_KEY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a26ed1878c832480b8e28f137e00cf