### PR TITLE
feat: align UI with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Kay Maria is built with a focus on calm, clarity, and emotional connection. Our 
 - Microinteractions
 - Tone and voice guidelines
 
+The style guide's core colors are exposed in Tailwind as utility classes like `bg-primary`, `text-foreground`, and `text-muted`.
+Use these to keep components visually consistent.
+
 To view a live preview of the design tokens and color palette in the app, visit:
 
 🔗 [`/style-guide`](http://localhost:3000/style-guide) (dev only)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,7 +125,7 @@ All items are **unchecked** to indicate upcoming work.
  - [x] Mobile UX refinements
    - [x] Respect device safe areas for notched screens
 
-- [ ] Align design with [Style Guide](./style-guide/page.tsx)
+ - [x] Align design with [Style Guide](./style-guide/page.tsx)
 
 - [ ] Shadcn/UI design polish and theming
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-body{@apply bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50;}
+body{@apply bg-background text-foreground dark:bg-neutral-900 dark:text-neutral-50;}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -14,13 +14,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
   ref
 ) {
   const base =
-    "inline-flex items-center justify-center rounded-xl font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-neutral-400 dark:focus-visible:ring-neutral-600 disabled:opacity-50 disabled:pointer-events-none";
+    "inline-flex items-center justify-center rounded-xl shadow-md font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/50 disabled:opacity-50 disabled:pointer-events-none";
   const byVariant =
     variant === "secondary"
-      ? "bg-neutral-100 text-neutral-900 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+      ? "bg-secondary text-foreground hover:bg-secondary/80"
       : variant === "ghost"
-      ? "bg-transparent text-neutral-900 hover:bg-neutral-100 dark:text-neutral-100 dark:hover:bg-neutral-800"
-      : "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200";
+      ? "bg-transparent text-foreground hover:bg-background"
+      : "bg-primary text-white hover:bg-primary/90";
   const bySize =
     size === "sm" ? "h-8 px-3 text-sm" : size === "icon" ? "h-10 w-10 p-0" : "h-10 px-4";
   return <button ref={ref} className={`${base} ${byVariant} ${bySize} ${className}`} {...props} />;

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,7 +8,7 @@ type PProps = React.HTMLAttributes<HTMLParagraphElement>;
 export function Card({ className = "", ...props }: DivProps) {
   return (
     <div
-      className={`rounded-xl border bg-white shadow-sm dark:bg-neutral-800 dark:border-neutral-700 ${className}`}
+      className={`rounded-xl border bg-white shadow-md dark:bg-neutral-800 dark:border-neutral-700 ${className}`}
       {...props}
     />
   );
@@ -20,7 +20,7 @@ export function CardTitle({ className = "", ...props }: HProps) {
   return <h3 className={`text-base font-medium ${className}`} {...props} />;
 }
 export function CardDescription({ className = "", ...props }: PProps) {
-  return <p className={`text-sm text-neutral-500 dark:text-neutral-400 ${className}`} {...props} />;
+  return <p className={`text-sm text-muted dark:text-neutral-400 ${className}`} {...props} />;
 }
 export function CardContent({ className = "", ...props }: DivProps) {
   return <div className={`p-4 ${className}`} {...props} />;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,13 @@ export default {
         display: ["Cabinet Grotesk", "ui-sans-serif", "system-ui", "sans-serif"],
         sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
       },
+      colors: {
+        primary: "#508C7E",
+        secondary: "#D3EDE6",
+        background: "#F9F9F9",
+        foreground: "#111827",
+        muted: "#9CA3AF",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- expose style guide colors through Tailwind
- apply new tokens to global, button, and card styles
- document design tokens and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script: "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a27013562c8324bce5c6d80782d7e2