### PR TITLE
Add error handling and loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🌤️ **Weather Awareness** – Current local weather for each plant using Open‑Meteo
 - 🔔 **Condition Alerts** – Notifies you when weather suggests watering or fertilizing soon
 - 🤖 **AI Care Recommendations** – Generates plant-specific watering, fertilizer, light, and repotting guidance
+- ⚠️ **Graceful Error States** – Custom 404 and 500 pages with a friendly loading experience
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,7 +146,7 @@ All items are **unchecked** to indicate upcoming work.
 
 - [ ] Deploy to Vercel
 - [ ] Manual test cases (mobile + desktop)
-- [ ] 404, 500 error handling and loading states
+- [x] 404, 500 error handling and loading states
 - [ ] Regression test for mock → live transition
 
 ---

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Something went wrong</h1>
+      <button className="mt-4 underline" onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+export default function Loading() {
+  return (
+    <div className="p-4 text-center">Loading...</div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Page Not Found</h1>
+      <p className="mt-2 text-muted-foreground">The page you're looking for doesn't exist.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add app-wide not-found, error, and loading components
- document new error handling behavior in README
- mark roadmap task for 404/500 pages as complete

## Testing
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2720fd57483248b1b2027b0906295