### PR TITLE
feat: add shadcn-style theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Kay Maria is built with a focus on calm, clarity, and emotional connection. Our 
 The style guide's core colors are exposed in Tailwind as utility classes like `bg-primary`, `text-foreground`, and `text-muted`.
 Use these to keep components visually consistent.
 
+The light and dark themes are powered by `next-themes` and Shadcn-style CSS variables defined in `app/globals.css`.
+
 To view a live preview of the design tokens and color palette in the app, visit:
 
 🔗 [`/style-guide`](http://localhost:3000/style-guide) (dev only)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,7 +127,7 @@ All items are **unchecked** to indicate upcoming work.
 
  - [x] Align design with [Style Guide](./style-guide/page.tsx)
 
-- [ ] Shadcn/UI design polish and theming
+- [x] Shadcn/UI design polish and theming
 
 ---
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-body{@apply bg-background text-foreground dark:bg-neutral-900 dark:text-neutral-50;}
+
+@layer base {
+  :root {
+    --background: 0 0% 98%;
+    --foreground: 221 39% 11%;
+    --primary: 166 27% 43%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 164 42% 88%;
+    --secondary-foreground: 221 39% 11%;
+    --muted: 218 11% 65%;
+  }
+  .dark {
+    --background: 221 39% 11%;
+    --foreground: 0 0% 98%;
+    --primary: 166 27% 43%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 164 42% 20%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 218 11% 65%;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
-import { use } from "react";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 export const metadata: Metadata = {
   title: "Kay Maria",
@@ -29,8 +29,8 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50">
-        {children}
+      <body className="min-h-screen bg-background text-foreground">
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,32 +1,21 @@
 "use client";
+import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
-  const [dark, setDark] = useState(false);
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
 
-  useEffect(() => {
-    const stored = typeof window !== "undefined" ? localStorage.getItem("theme") : null;
-    const isDark = stored === "dark";
-    setDark(isDark);
-    document.documentElement.classList.toggle("dark", isDark);
-  }, []);
+  useEffect(() => setMounted(true), []);
 
-  function toggle() {
-    const isDark = !dark;
-    setDark(isDark);
-    document.documentElement.classList.toggle("dark", isDark);
-    if (isDark) {
-      localStorage.setItem("theme", "dark");
-    } else {
-      localStorage.setItem("theme", "light");
-    }
-  }
+  if (!mounted) return null;
 
   return (
     <button
-      onClick={toggle}
-      className="border rounded px-3 py-2 text-sm" >
-      {dark ? "Light Mode" : "Dark Mode"}
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="border rounded px-3 py-2 text-sm"
+    >
+      {theme === "dark" ? "Light Mode" : "Dark Mode"}
     </button>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "framer-motion": "^11.0.0",
         "lucide-react": "^0.452.0",
         "next": "latest",
+        "next-themes": "^0.2.1",
         "openai": "^4.104.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -2418,6 +2419,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.452.0",
     "next": "latest",
+    "next-themes": "^0.2.1",
     "openai": "^4.104.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  darkMode: ["class", '[data-theme="dark"]'],
+  darkMode: ["class"],
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -14,11 +14,17 @@ export default {
         sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
       },
       colors: {
-        primary: "#508C7E",
-        secondary: "#D3EDE6",
-        background: "#F9F9F9",
-        foreground: "#111827",
-        muted: "#9CA3AF",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: "hsl(var(--muted))",
       },
     },
   },


### PR DESCRIPTION
## Summary
- integrate `next-themes` provider and shadcn-style CSS variables for light/dark mode
- update ThemeToggle and layout to use shared theme provider
- document theming approach in README and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a273fa14d48324bf79b2629f62f869