### PR TITLE
Add care plan editing modal

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Droplet, FlaskConical, Sprout, Pencil } from "lucide-react";
 import EditPlantModal from '@/components/EditPlantModal';
+import EditCarePlanModal from '@/components/EditCarePlanModal';
 import BottomNav from '@/components/BottomNav';
 
 type CareType = "water" | "fertilize" | "repot";
@@ -63,6 +64,7 @@ export default function PlantDetailClient({ plant }: { plant: {
     const [noteText, setNoteText] = useState("");
   const [undoInfo, setUndoInfo] = useState<{ task: TaskDTO; eventAt: string } | null>(null);
   const [editOpen, setEditOpen] = useState(false);
+  const [careOpen, setCareOpen] = useState(false);
   const [weather, setWeather] = useState<{ temperature: number } | null>(null);
   const careTips = useMemo(() => {
     const tips: string[] = [];
@@ -307,35 +309,43 @@ export default function PlantDetailClient({ plant }: { plant: {
         </div>
 
         {tab === "stats" && (
-          <div className="grid grid-cols-2 gap-3 mt-4">
-            <Stat
-              label="Water"
-              value={
-                plantState.waterIntervalDays
-                  ? `Every ${plantState.waterIntervalDays}d${nextWater ? ` • next ${fmt(nextWater)}` : ""}`
-                  : "—"
-              }
-            />
-            <Stat
-              label="Fertilize"
-              value={
-                plantState.fertilizeIntervalDays
-                  ? `Every ${plantState.fertilizeIntervalDays}d${nextFertilize ? ` • next ${fmt(nextFertilize)}` : ""}`
-                  : "—"
-              }
-            />
-            <Stat label="Light" value={plantState.light || plantState.lightLevel || "—"} />
-            <Stat label="Humidity" value={plantState.humidity || "—"} />
-            <Stat label="Weather" value={weather ? `${Math.round(weather.temperature)}°C` : "—"} />
-            <Stat
-              label="Pot"
-              value={
-                plantState.potSize
-                  ? `${plantState.potSize}${plantState.potMaterial ? ` ${plantState.potMaterial}` : ""}`
-                  : "—"
-              }
-            />
-            <Stat label="Soil" value={plantState.soilType || "—"} />
+          <div className="mt-4">
+            <div className="grid grid-cols-2 gap-3">
+              <Stat
+                label="Water"
+                value={
+                  plantState.waterIntervalDays
+                    ? `Every ${plantState.waterIntervalDays}d${nextWater ? ` • next ${fmt(nextWater)}` : ""}`
+                    : "—"
+                }
+              />
+              <Stat
+                label="Fertilize"
+                value={
+                  plantState.fertilizeIntervalDays
+                    ? `Every ${plantState.fertilizeIntervalDays}d${nextFertilize ? ` • next ${fmt(nextFertilize)}` : ""}`
+                    : "—"
+                }
+              />
+              <Stat label="Light" value={plantState.light || plantState.lightLevel || "—"} />
+              <Stat label="Humidity" value={plantState.humidity || "—"} />
+              <Stat label="Weather" value={weather ? `${Math.round(weather.temperature)}°C` : "—"} />
+              <Stat
+                label="Pot"
+                value={
+                  plantState.potSize
+                    ? `${plantState.potSize}${plantState.potMaterial ? ` ${plantState.potMaterial}` : ""}`
+                    : "—"
+                }
+              />
+              <Stat label="Soil" value={plantState.soilType || "—"} />
+            </div>
+            <button
+              className="mt-4 w-full border rounded-lg px-3 py-2"
+              onClick={() => setCareOpen(true)}
+            >
+              Edit Care Plan
+            </button>
           </div>
         )}
 
@@ -446,6 +456,12 @@ export default function PlantDetailClient({ plant }: { plant: {
           setName(p.name);
           setSpecies(p.species || "");
         }}
+      />
+      <EditCarePlanModal
+        open={careOpen}
+        onOpenChange={setCareOpen}
+        plant={plantState}
+        onUpdated={(p) => setPlantState(p)}
       />
     </div>
   );

--- a/components/EditCarePlanModal.tsx
+++ b/components/EditCarePlanModal.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function EditCarePlanModal({
+  open,
+  plant,
+  onOpenChange,
+  onUpdated,
+}: {
+  open: boolean;
+  plant: { id: string; rules?: any[] };
+  onOpenChange: (v: boolean) => void;
+  onUpdated: (p: any) => void;
+}) {
+  const [waterEvery, setWaterEvery] = useState('');
+  const [waterAmount, setWaterAmount] = useState('');
+  const [fertEvery, setFertEvery] = useState('');
+  const [fertAmount, setFertAmount] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    const w = plant.rules?.find((r: any) => r.type === 'water') || {};
+    const f = plant.rules?.find((r: any) => r.type === 'fertilize') || {};
+    setWaterEvery(w.intervalDays ? String(w.intervalDays) : '');
+    setWaterAmount(w.amountMl ? String(w.amountMl) : '');
+    setFertEvery(f.intervalDays ? String(f.intervalDays) : '');
+    setFertAmount(f.amountMl ? String(f.amountMl) : '');
+  }, [plant, open]);
+
+  function close() {
+    onOpenChange(false);
+  }
+
+  async function save() {
+    const rules = [
+      { type: 'water', intervalDays: Number(waterEvery || 0), amountMl: Number(waterAmount || 0) },
+      { type: 'fertilize', intervalDays: Number(fertEvery || 0), amountMl: Number(fertAmount || 0) },
+    ];
+    try {
+      const r = await fetch(`/api/plants/${plant.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rules }),
+      });
+      if (r.ok) {
+        const r2 = await fetch(`/api/plants/${plant.id}`, { cache: 'no-store' });
+        if (r2.ok) {
+          const updated = await r2.json();
+          const w = updated.rules?.find((r: any) => r.type === 'water') || {};
+          const f = updated.rules?.find((r: any) => r.type === 'fertilize') || {};
+          onUpdated({
+            ...plant,
+            ...updated,
+            waterIntervalDays: w.intervalDays,
+            waterAmountMl: w.amountMl,
+            fertilizeIntervalDays: f.intervalDays,
+            fertilizeAmountMl: f.amountMl,
+          });
+        }
+      }
+    } catch {
+      /* ignore errors in mock env */
+    }
+    close();
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 grid place-items-center p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-4 shadow-xl">
+        <div className="mb-2">
+          <div className="text-lg font-semibold">Edit Care Plan</div>
+          <div className="text-sm text-neutral-600">Update watering and fertilizing schedule.</div>
+        </div>
+        <div className="grid gap-3">
+          <div className="grid gap-1">
+            <label className="text-sm">Water every (days)</label>
+            <input
+              className="border rounded px-3 py-2"
+              value={waterEvery}
+              onChange={(e) => setWaterEvery(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Water amount (ml)</label>
+            <input
+              className="border rounded px-3 py-2"
+              value={waterAmount}
+              onChange={(e) => setWaterAmount(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Fertilize every (days)</label>
+            <input
+              className="border rounded px-3 py-2"
+              value={fertEvery}
+              onChange={(e) => setFertEvery(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Fertilize amount (ml)</label>
+            <input
+              className="border rounded px-3 py-2"
+              value={fertAmount}
+              onChange={(e) => setFertAmount(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="mt-3 flex gap-2 justify-end">
+          <button className="border rounded px-3 py-2" onClick={close}>
+            Cancel
+          </button>
+          <button
+            className="bg-neutral-900 text-white rounded px-3 py-2"
+            onClick={save}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add EditCarePlanModal for updating watering and fertilizing intervals and amounts
- show "Edit Care Plan" button in plant detail stats and connect modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: OPENAI_API_KEY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2760bb19483249a8a46f62eca37ce