### PR TITLE
Add manual test cases documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Once the development server is running:
 4. Swipe a task to complete it, edit the details, or delete it.
 5. Use the room and task-type filters to focus on what's relevant.
 
+
+## 🧪 Testing
+
+Manual test cases for desktop and mobile are documented in [docs/manual-test-cases.md](./docs/manual-test-cases.md).
+
 # 🌱 Kay Maria
 
 **Tend to what matters.**  

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,7 +145,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] Add `README.md` with usage instructions
 
 - [ ] Deploy to Vercel
-- [ ] Manual test cases (mobile + desktop)
+- [x] Manual test cases (mobile + desktop) ([docs/manual-test-cases.md](./docs/manual-test-cases.md))
 - [x] 404, 500 error handling and loading states
 - [ ] Regression test for mock → live transition
 

--- a/docs/manual-test-cases.md
+++ b/docs/manual-test-cases.md
@@ -1,0 +1,20 @@
+# Manual Test Cases
+
+This document outlines manual test cases for verifying Kay Maria's core flows on desktop and mobile devices.
+
+## Desktop
+
+- **Home Dashboard**: Visit `/app` and confirm today's tasks list appears with overdue items highlighted.
+- **Add Plant**: Use the **+** button to add a plant. Verify default care tasks are scheduled.
+- **Complete Task**: Mark a task as done and ensure it moves to the plant's timeline with a confirmation message.
+- **Filters**: Apply room or task-type filters and confirm the task list updates accordingly.
+- **Theme Toggle**: Switch between light and dark modes in settings and confirm the preference persists on refresh.
+
+## Mobile
+
+- **Responsive Layout**: Load `/app` on a device or emulator at mobile width and confirm the layout adapts with the FAB in the lower-right.
+- **Swipe Actions**: Swipe a task card left or right to reveal actions for completion, deferral, or edit.
+- **Upcoming View**: Navigate to the Upcoming view and verify tasks due within the configured window appear grouped by plant.
+- **Inline Notes**: Add a quick note to a task card and confirm it saves and displays in the timeline.
+- **Undo Completion**: After marking a task done, use the undo option to restore it.
+


### PR DESCRIPTION
## Summary
- document desktop and mobile manual test cases
- note manual testing details in README
- mark roadmap item for manual testing as complete

## Testing
- `npm test` (fails: Missing script "test")
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a276ba34608324ae10f0c68ee2a47b