### PR TITLE
Use modal for filter controls

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -9,6 +9,7 @@ import QuickAddModal from "@/components/QuickAddModal";
 import AddPlantModal from "@/components/AddPlantModal";
 import EditTaskModal from "@/components/EditTaskModal";
 import ThemeToggle from "@/components/ThemeToggle";
+import FiltersModal from "@/components/FiltersModal";
 import { TaskDTO } from "@/lib/types";
 import { motion } from "framer-motion";
 import { Check } from "lucide-react";
@@ -98,6 +99,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
   const [taskWindow, setTaskWindow] = useState(DEFAULT_TASK_WINDOW_DAYS);
 
   // modals
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [addPlantOpen, setAddPlantOpen] = useState(false);
   const [prefillPlantName, setPrefillPlantName] = useState("");
@@ -508,40 +510,13 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
                 </div>
               </div>
             )}
-            <div className="mt-3 space-y-2">
-              <select
-                value={roomFilter}
-                onChange={(e) => setRoomFilter(e.target.value)}
+            <div className="mt-3">
+              <button
                 className="border rounded px-3 py-2 w-full"
+                onClick={() => setFiltersOpen(true)}
               >
-                <option value="">All rooms</option>
-                {rooms.map((r) => (
-                  <option key={r} value={r}>
-                    {r}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={typeFilter}
-                onChange={(e) => setTypeFilter(e.target.value)}
-                className="border rounded px-3 py-2 w-full"
-              >
-                <option value="">All task types</option>
-                {types.map((t) => (
-                  <option key={t} value={t}>
-                    {labelForType(t as any)}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
-                className="border rounded px-3 py-2 w-full"
-              >
-                <option value="">All statuses</option>
-                <option value="overdue">Overdue</option>
-                <option value="urgent">Due soon</option>
-              </select>
+                Filters
+              </button>
             </div>
           </>
         )}
@@ -665,16 +640,12 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
               <div className="text-xs text-neutral-500">Recent care events</div>
             </div>
             <div className="px-4 py-2 border-b">
-              <select
-                value={eventTypeFilter}
-                onChange={(e) => setEventTypeFilter(e.target.value)}
+              <button
                 className="border rounded px-3 py-2 w-full"
+                onClick={() => setFiltersOpen(true)}
               >
-                <option value="">All event types</option>
-                <option value="water">Water</option>
-                <option value="fertilize">Fertilize</option>
-                <option value="repot">Repot</option>
-              </select>
+                Filters
+              </button>
             </div>
             <ul className="text-sm px-4 py-2">
               {eventsErr && <li className="py-3 text-red-600">{eventsErr}</li>}
@@ -815,6 +786,21 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
           )}
         </div>
       )}
+
+      <FiltersModal
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        rooms={rooms}
+        roomFilter={roomFilter}
+        setRoomFilter={setRoomFilter}
+        types={types}
+        typeFilter={typeFilter}
+        setTypeFilter={setTypeFilter}
+        statusFilter={statusFilter}
+        setStatusFilter={setStatusFilter}
+        eventTypeFilter={eventTypeFilter}
+        setEventTypeFilter={setEventTypeFilter}
+      />
 
       <EditTaskModal
         open={!!editTask}

--- a/components/FiltersModal.tsx
+++ b/components/FiltersModal.tsx
@@ -1,0 +1,88 @@
+'use client';
+import React from 'react';
+
+function labelForType(t: string) {
+  return t === 'water' ? 'Water' : t === 'fertilize' ? 'Fertilize' : 'Repot';
+}
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  rooms: string[];
+  roomFilter: string;
+  setRoomFilter: (v: string) => void;
+  types: string[];
+  typeFilter: string;
+  setTypeFilter: (v: string) => void;
+  statusFilter: string;
+  setStatusFilter: (v: string) => void;
+  eventTypeFilter: string;
+  setEventTypeFilter: (v: string) => void;
+};
+
+export default function FiltersModal({
+  open,
+  onClose,
+  rooms,
+  roomFilter,
+  setRoomFilter,
+  types,
+  typeFilter,
+  setTypeFilter,
+  statusFilter,
+  setStatusFilter,
+  eventTypeFilter,
+  setEventTypeFilter,
+}: Props) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="absolute inset-0 bg-black/30" />
+      <div className="relative w-full sm:max-w-sm bg-white rounded-t-2xl sm:rounded-2xl p-4 shadow-xl max-h-[90vh] overflow-y-auto">
+        <div className="mb-3">
+          <div className="text-lg font-semibold">Filters</div>
+        </div>
+        <div className="space-y-3">
+          <div className="grid gap-1">
+            <label className="text-sm">Room</label>
+            <select className="border rounded px-3 py-2 w-full" value={roomFilter} onChange={(e) => setRoomFilter(e.target.value)}>
+              <option value="">All rooms</option>
+              {rooms.map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Task type</label>
+            <select className="border rounded px-3 py-2 w-full" value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+              <option value="">All task types</option>
+              {types.map((t) => (
+                <option key={t} value={t}>{labelForType(t)}</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Status</label>
+            <select className="border rounded px-3 py-2 w-full" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
+              <option value="">All statuses</option>
+              <option value="overdue">Overdue</option>
+              <option value="urgent">Due soon</option>
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm">Event type</label>
+            <select className="border rounded px-3 py-2 w-full" value={eventTypeFilter} onChange={(e) => setEventTypeFilter(e.target.value)}>
+              <option value="">All event types</option>
+              <option value="water">Water</option>
+              <option value="fertilize">Fertilize</option>
+              <option value="repot">Repot</option>
+            </select>
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button className="border rounded px-3 py-2" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace stacked selects with a single Filters button
- Introduce FiltersModal to house room, task type, status, and event type filters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2783103bc83249d59222d168d9622