### PR TITLE
feat: add overdue task notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Once the development server is running:
 3. Tap a plant card to view its quick stats, timeline, notes, or photo gallery.
 4. Swipe a task to complete it, edit the details, or delete it.
 5. Use the room and task-type filters to focus on what's relevant.
+6. Allow browser notifications to get alerts for overdue tasks.
 
 
 ## 🧪 Testing
@@ -88,6 +89,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🌗 **Light/Dark Mode** – Toggle the interface theme from Settings
 - 🌤️ **Weather Awareness** – Current local weather for each plant using Open‑Meteo
 - 🔔 **Condition Alerts** – Notifies you when weather suggests watering or fertilizing soon
+- ⏰ **Overdue Task Notifications** – Browser alerts when care tasks are past due
 - 🤖 **AI Care Recommendations** – Generates plant-specific watering, fertilizer, light, and repotting guidance
 - ⚠️ **Graceful Error States** – Custom 404 and 500 pages with a friendly loading experience
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,7 +153,7 @@ All items are **unchecked** to indicate upcoming work.
 
 ## 💡 Backlog & Ideas
 
-- [ ] Notifications for overdue care
+- [x] Notifications for overdue care
 - [ ] Shareable plant profiles (public link)
 - [ ] Visual analytics dashboard
 - [ ] Native app support (PWA or React Native)

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -118,6 +118,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
   const [tasks, setTasks] = useState<TaskDTO[]>([]);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const notifiedRef = useRef<Set<string>>(new Set());
 
   // events list for Timeline tab
   const [events, setEvents] = useState<EventDTO[]>([]);
@@ -187,6 +188,29 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
   useEffect(() => {
     refresh(taskWindow);
   }, [taskWindow]);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      "Notification" in window &&
+      Notification.permission === "default"
+    ) {
+      Notification.requestPermission();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) return;
+    if (Notification.permission !== "granted") return;
+    const now = Date.now();
+    tasks.forEach((t) => {
+      const due = new Date(t.dueAt).getTime();
+      if (due < now && !notifiedRef.current.has(t.id)) {
+        new Notification(`${t.plantName}: ${labelForType(t.type)} overdue`);
+        notifiedRef.current.add(t.id);
+      }
+    });
+  }, [tasks]);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- add browser notifications for overdue plant care tasks
- document notifications and mark roadmap item complete

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Missing OpenAI API key)


------
https://chatgpt.com/codex/tasks/task_e_68a27b5dc7d08324ae4348df809feab6