### PR TITLE
Defer OpenAI client initialization in care recommendations API

### DIFF
--- a/app/api/ai/care-recommend/route.ts
+++ b/app/api/ai/care-recommend/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 function getSeason(date: Date = new Date()): string {
   const month = date.getMonth() + 1;
   if (month >= 3 && month <= 5) return "spring";
@@ -12,12 +10,15 @@ function getSeason(date: Date = new Date()): string {
 }
 
 export async function POST(req: NextRequest) {
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     return NextResponse.json(
       { error: "OPENAI_API_KEY not set" },
       { status: 500 }
     );
   }
+
+  const client = new OpenAI({ apiKey });
 
   const body = await req.json().catch(() => ({}));
   const species = body.species ?? "Unknown plant";


### PR DESCRIPTION
## Summary
- Avoid OpenAI client instantiation at module load
- Initialize OpenAI client inside POST handler after verifying `OPENAI_API_KEY`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a27c7237408324927ff8faa0f9537c