### PR TITLE
feat: add AI fine-tuning script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .env.local
 .env.local
 .env
+fine-tune-data.jsonl

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🔔 **Condition Alerts** – Notifies you when weather suggests watering or fertilizing soon
 - ⏰ **Overdue Task Notifications** – Browser alerts when care tasks are past due
 - 🤖 **AI Care Recommendations** – Generates plant-specific watering, fertilizer, light, and repotting guidance
+- 🔁 **AI Fine-Tuning** – Create custom models using your care logs
 - ⚠️ **Graceful Error States** – Custom 404 and 500 pages with a friendly loading experience
 
 ---
@@ -225,4 +226,16 @@ curl -X POST http://localhost:3000/api/ai/care-recommend \\
 ```
 
 The feedback is included in the AI prompt so new suggestions are adjusted accordingly.
+
+## 🔁 AI Fine-Tuning
+
+You can experiment with fine-tuning the AI using completed care logs from the mock data.
+
+Generate a training file and submit a fine-tune job to OpenAI:
+
+```bash
+npm run ai:fine-tune
+```
+
+The script writes `fine-tune-data.jsonl` to the project root and, if `OPENAI_API_KEY` is set, uploads it to OpenAI and starts a fine-tune job.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,7 +103,7 @@ All items are **unchecked** to indicate upcoming work.
 - [x] Learn from user input:
   - [x] Feedback (e.g. “too much water”)
   - [x] Adjust future care suggestions
-- [ ] Long-term idea: fine-tune a model using user care logs
+ - [x] Long-term idea: fine-tune a model using user care logs
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "db:migrate": "prisma migrate dev",
-    "db:seed": "prisma db seed"
+    "db:seed": "prisma db seed",
+    "ai:fine-tune": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/fine-tune.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.14.0",

--- a/scripts/fine-tune.ts
+++ b/scripts/fine-tune.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import OpenAI from "openai";
+import { mockPlants } from "../mock/plants";
+import { mockTasks } from "../mock/tasks";
+
+async function generateTrainingFile(path: string) {
+  const examples = mockTasks
+    .filter((t) => t.completed)
+    .map((t) => {
+      const plant = mockPlants.find((p) => p.id === t.plantId);
+      return {
+        messages: [
+          { role: "system", content: "You are a plant care assistant." },
+          {
+            role: "user",
+            content: `I ${t.type}ed my ${plant?.name}. Notes: ${t.notes ?? ""}`,
+          },
+          {
+            role: "assistant",
+            content: `Logged ${t.type} for ${plant?.name}.`,
+          },
+        ],
+      };
+    });
+
+  fs.writeFileSync(path, examples.map((e) => JSON.stringify(e)).join("\n"));
+  return path;
+}
+
+async function main() {
+  const filePath = await generateTrainingFile("fine-tune-data.jsonl");
+  console.log(`Wrote training data to ${filePath}`);
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.log("OPENAI_API_KEY not set; skipping fine-tune job submission.");
+    return;
+  }
+
+  const client = new OpenAI({ apiKey });
+  const file = await client.files.create({
+    file: fs.createReadStream(filePath),
+    purpose: "fine-tune",
+  });
+  const job = await client.fineTuning.jobs.create({
+    training_file: file.id,
+    model: "gpt-3.5-turbo",
+  });
+  console.log("Fine-tune job created:", job.id);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to build care log training data and submit OpenAI fine-tune job
- expose script via `npm run ai:fine-tune`
- document fine-tuning support in README and mark roadmap item complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `OPENAI_API_KEY=dummy npm run build`
- `npm run ai:fine-tune`


------
https://chatgpt.com/codex/tasks/task_e_68a27cc26454832480a11f34ef64c7d4