### PR TITLE
Ensure header overlays content with z-index

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -483,7 +483,7 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
   return (
     <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
       <header
-        className="px-4 pb-2 sticky top-0 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
+        className="px-4 pb-2 sticky top-0 z-20 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}
       >
         <div className="flex items-baseline justify-between w-full">


### PR DESCRIPTION
## Summary
- add Tailwind `z-20` utility to `<header>` in `AppShell` so dropdowns and header sit above page content

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2815340b08324b7f10e9d9a6b2edf