### PR TITLE
Remove quick note feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🏠 **Room Filters** – Focus on tasks for a specific room or location
 - 🔍 **Task Type Filters** – Filter tasks by action (water, fertilize, repot)
 - ⏰ **Overdue/Urgent Filters** – Show only overdue tasks or those due soon
-- 📝 **Quick Notes** – Jot down observations directly from any task card
 - ✅ **Inline Task Actions** – Mark tasks done, defer them, or edit details without leaving the dashboard
 - 👉 **Swipe Actions** – Swipe a task to quickly complete, edit, or delete it
 - 🎉 **Completion Feedback** – Subtle check animation and timestamp confirmation when tasks are marked done
@@ -165,7 +164,7 @@ To enable local weather in the app, include `latitude` and `longitude` when crea
 - `PATCH /api/plants/:id` – update fields on a plant
 - `DELETE /api/plants/:id` – remove a plant and its tasks
 - `GET /api/plants/:id/notes` – list notes for a plant
-- `POST /api/plants/:id/notes` – add a quick note
+- `POST /api/plants/:id/notes` – add a note
 - `GET /api/plants/:id/photos` – list photos for a plant
 - `POST /api/plants/:id/photos` – add a photo by URL
 - `GET /api/plants/:id/weather` – current weather for a plant

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,6 @@ All items are **unchecked** to indicate upcoming work.
 - [x] **Group tasks by plant**: Visual hierarchy that nests or groups tasks under each plant
 - [x] **Sort by urgency**: Sort tasks by due date/time within each plant group
 - [x] **Task icons**: Use visual icons (💧 Water, 🌱 Fertilize, 🪴 Repot) for quick scanning
-- [x] **Quick Notes**: Allow inline note-taking for a plant directly from the task card (e.g., "drooping today" or "spotted new growth")
 - [x] **Inline task actions**:
   - [x] Mark as done (with subtle animation or feedback)
   - [x] Defer (e.g., "Remind me tomorrow")

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -324,20 +324,6 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
 
   
 
-  const addNote = async (plantId: string, text: string) => {
-    try {
-      const r = await fetch(`/api/plants/${plantId}/notes`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text }),
-      });
-      if (!r.ok) throw new Error();
-      toast("Note added");
-    } catch {
-      toast("Failed to add note");
-    }
-  };
-
   const today = new Date();
   const tasksToday = useMemo(() => {
     const tomorrow = new Date(
@@ -543,7 +529,6 @@ export default function AppShell({ initialView }:{ initialView?: "today"|"timeli
                         due={dueLabel(new Date(t.dueAt), today)}
                         onOpen={() => {}}
                         onComplete={() => complete(t)}
-                        onAddNote={(note) => addNote(t.plantId, note)}
                         onDefer={() => deferTask(t)}
                         showPlant={false}
                       />

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import {
-  Check,
-  Clock,
-  StickyNote,
-  Droplet,
-  FlaskConical,
-  Sprout,
-  Leaf,
-} from 'lucide-react';
-import { useState } from 'react';
+import { Check, Clock, Droplet, FlaskConical, Sprout, Leaf } from 'lucide-react';
 
 export default function TaskRow({
   plant,
@@ -19,7 +10,6 @@ export default function TaskRow({
   due,
   onOpen,
   onComplete,
-  onAddNote,
   onDefer,
   showPlant = true,
 }: {
@@ -29,7 +19,6 @@ export default function TaskRow({
   due: string;
   onOpen: () => void;
   onComplete: () => void;
-  onAddNote: (note: string) => void;
   onDefer: () => void;
   showPlant?: boolean;
 }) {
@@ -41,8 +30,6 @@ export default function TaskRow({
       ? <FlaskConical className={className} />
       : <Sprout className={className} />;
   }
-  const [noteOpen, setNoteOpen] = useState(false);
-  const [note, setNote] = useState('');
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl overflow-hidden">
@@ -109,42 +96,10 @@ export default function TaskRow({
                 >
                   <Clock className="h-4 w-4" />
                 </button>
-                <button
-                  aria-label="Add note"
-                  onClick={() => setNoteOpen((v) => !v)}
-                  className="p-2 rounded hover:bg-neutral-100 dark:hover:bg-neutral-700"
-                >
-                  <StickyNote className="h-4 w-4" />
-                </button>
               </div>
             </div>
           </div>
         </div>
-        {noteOpen && (
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (!note.trim()) return;
-              onAddNote(note.trim());
-              setNote('');
-              setNoteOpen(false);
-            }}
-            className="flex items-center gap-2 border-t p-3"
-          >
-            <input
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder="Quick note..."
-              className="flex-1 text-sm border rounded px-2 py-1"
-            />
-            <button
-              type="submit"
-              className="text-sm px-2 py-1 rounded bg-neutral-100"
-            >
-              Save
-            </button>
-          </form>
-        )}
       </motion.div>
     </div>
   );

--- a/docs/manual-test-cases.md
+++ b/docs/manual-test-cases.md
@@ -15,6 +15,5 @@ This document outlines manual test cases for verifying Kay Maria's core flows on
 - **Responsive Layout**: Load `/app` on a device or emulator at mobile width and confirm the layout adapts with the FAB in the lower-right.
 - **Swipe Actions**: Swipe a task card left or right to reveal actions for completion, deferral, or edit.
 - **Upcoming View**: Navigate to the Upcoming view and verify tasks due within the configured window appear grouped by plant.
-- **Inline Notes**: Add a quick note to a task card and confirm it saves and displays in the timeline.
 - **Undo Completion**: After marking a task done, use the undo option to restore it.
 


### PR DESCRIPTION
## Summary
- remove quick note input from task row and drop related API calls
- clean up docs and tests mentioning quick notes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a28b1149fc8324a8224550b6e9533d