### PR TITLE
docs: refresh readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
+# 🌱 Kay Maria
 
-# Plant MVP (Mock Data) v2
+**Tend to what matters.**
+_A calm, intelligent plant care companion designed for clarity, beauty, and emotional connection._
+
+---
+
+## Overview
+
+Kay Maria is a thoughtful plant tracking app that helps you care for your plants with ease. Inspired by the simplicity of journaling and the intelligence of modern tools, it combines task management, smart care suggestions, and gentle design.
+
+Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space, habits, and environment — with no pressure and no ads.
 
 ## Getting Started
 
-1. Copy `.env.local.example` to `.env.local` and fill in your values.
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone https://github.com/osmond/kaymaria.git
+   cd kaymaria
+   npm install
+   ```
+2. Copy `.env.local.example` to `.env.local` and fill in your values.
    - `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` come from your Supabase project.
    - `NEXT_PUBLIC_BASE_URL` should point to the URL where the app runs.
    - `DATABASE_URL` is used by Prisma; the example file defaults to a local SQLite database.
-   - `NEXT_PUBLIC_TASK_WINDOW_DAYS` controls how many days ahead the Upcoming view looks (default `7`)
-   - `OPENAI_API_KEY` enables AI-powered care recommendations
-2. Install dependencies, seed the database, and start the development server:
-
-```bash
-npm install
-npm run db:migrate
-npm run db:seed
-npm run dev
-# open http://localhost:3000/app
-```
+   - `NEXT_PUBLIC_TASK_WINDOW_DAYS` controls how many days ahead the Upcoming view looks (default `7`).
+   - `OPENAI_API_KEY` enables AI-powered care recommendations.
+3. Run migrations, seed the database, and start the development server:
+   ```bash
+   npm run db:migrate
+   npm run db:seed
+   npm run dev
+   # open http://localhost:3000/app
+   ```
 
 To create a production build run:
-
 ```bash
 npm run build
 ```
@@ -36,25 +49,9 @@ Once the development server is running:
 5. Use the room and task-type filters to focus on what's relevant.
 6. Allow browser notifications to get alerts for overdue tasks.
 
-
 ## 🧪 Testing
 
 Manual test cases for desktop and mobile are documented in [docs/manual-test-cases.md](./docs/manual-test-cases.md).
-
-# 🌱 Kay Maria
-
-**Tend to what matters.**  
-_A calm, intelligent plant care companion designed for clarity, beauty, and emotional connection._
-
----
-
-## Overview
-
-Kay Maria is a thoughtful plant tracking app that helps you care for your plants with ease. Inspired by the simplicity of journaling and the intelligence of modern tools, it combines task management, smart care suggestions, and gentle design.
-
-Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space, habits, and environment — with no pressure and no ads.
-
----
 
 ## ✨ Features
 
@@ -94,12 +91,11 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 - 🔁 **AI Fine-Tuning** – Create custom models using your care logs
 - ⚠️ **Graceful Error States** – Custom 404 and 500 pages with a friendly loading experience
 
----
-
 ## 🚧 Current Status
 
-This project is under active development.  
+This project is under active development.
 Check out [ROADMAP.md](./ROADMAP.md) for upcoming milestones and goals.
+
 ## 🧑‍🎨 Design System
 
 Kay Maria is built with a focus on calm, clarity, and emotional connection. Our visual language is defined in the [Visual Style Guide](./docs/style-guide.md), including:
@@ -119,18 +115,6 @@ The light and dark themes are powered by `next-themes` and Shadcn-style CSS vari
 To view a live preview of the design tokens and color palette in the app, visit:
 
 🔗 [`/style-guide`](http://localhost:3000/style-guide) (dev only)
-
----
-
-## 📦 Local Development
-
-```bash
-git clone https://github.com/osmond/kaymaria.git
-cd kaymaria
-npm install
-cp .env.local.example .env.local
-npm run dev
-```
 
 ## ☁️ Deployment
 
@@ -171,10 +155,9 @@ To enable local weather in the app, include `latitude` and `longitude` when crea
 - `GET /api/plants/:id/weather` – current weather for a plant
 
 Example:
-
 ```bash
-curl -X POST http://localhost:3000/api/plants \\
-  -H 'Content-Type: application/json' \\
+curl -X POST http://localhost:3000/api/plants \
+  -H 'Content-Type: application/json' \
   -d '{"name":"Palm","potSize":"10in","potMaterial":"plastic","soilType":"well-draining","latitude":40.71,"longitude":-74.00,"rules":[{"type":"water","intervalDays":5},{"type":"fertilize","intervalDays":30}]}'
 ```
 
@@ -187,7 +170,6 @@ Tasks represent upcoming care actions for your plants. Completed tasks automatic
 - `PATCH /api/tasks/:id` – mark a task complete and record the event
 
 Example:
-
 ```bash
 curl -X PATCH http://localhost:3000/api/tasks/t_<uuid>
 ```
@@ -205,8 +187,8 @@ Backup or restore plants and tasks using these endpoints:
 Request plant-specific care guidance powered by OpenAI:
 
 ```bash
-curl -X POST http://localhost:3000/api/ai/care-recommend \\
-  -H 'Content-Type: application/json' \\
+curl -X POST http://localhost:3000/api/ai/care-recommend \
+  -H 'Content-Type: application/json' \
   -d '{"species":"Monstera deliciosa","potSize":"8in","potMaterial":"terracotta","soilType":"well-draining","lightLevel":"bright indirect","humidity":"medium","season":"winter","location":"living room"}'
 ```
 
@@ -218,10 +200,9 @@ Include optional fields:
 - `feedback` to tweak future recommendations based on previous guidance (e.g. `"too much water"`).
 
 Example with feedback:
-
 ```bash
-curl -X POST http://localhost:3000/api/ai/care-recommend \\
-  -H 'Content-Type: application/json' \\
+curl -X POST http://localhost:3000/api/ai/care-recommend \
+  -H 'Content-Type: application/json' \
   -d '{"species":"Monstera deliciosa","feedback":"too much water"}'
 ```
 
@@ -232,10 +213,8 @@ The feedback is included in the AI prompt so new suggestions are adjusted accord
 You can experiment with fine-tuning the AI using completed care logs from the mock data.
 
 Generate a training file and submit a fine-tune job to OpenAI:
-
 ```bash
 npm run ai:fine-tune
 ```
 
 The script writes `fine-tune-data.jsonl` to the project root and, if `OPENAI_API_KEY` is set, uploads it to OpenAI and starts a fine-tune job.
-


### PR DESCRIPTION
## Summary
- rewrite README to reflect Kay Maria project name
- consolidate getting started steps and clarify environment variables
- streamline deployment and API documentation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a28bf68f108324971aa33cd1412d6e