### PR TITLE
docs: expand roadmap deliverables

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,19 @@ This document outlines upcoming work for the Kay Maria plant care app.
 All items are unchecked to indicate pending tasks.
 
 - [ ] Multi-device sync
+  - [ ] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
+  - [ ] Real-time data sync across devices
+  - [ ] Shared preferences and settings
 - [ ] Regression tests
+  - [ ] End-to-end test suite
+  - [ ] Continuous integration pipeline
+  - [ ] Manual test cases documentation ([#75](https://github.com/osmond/kaymaria/issues/75))
 - [ ] Analytics dashboard
+  - [ ] Usage tracking and event logging
+  - [ ] Trend visualization for plant care
+  - [ ] Admin dashboard UI
 - [ ] Native app support
+  - [ ] PWA shell
+  - [ ] Offline caching
+  - [ ] App store deployment
 


### PR DESCRIPTION
## Summary
- expand roadmap with detailed deliverables
- link to existing GitHub issues where relevant

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a29250e1cc8324acd06791bfc3d207