### PR TITLE
Add insights page with charts

### DIFF
--- a/app/app/insights/page.tsx
+++ b/app/app/insights/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import BottomNav from "@/components/BottomNav";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+type Insights = { plantCount: number; taskCount: number };
+
+export default function InsightsPage() {
+  const [data, setData] = useState<Insights | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setErr(null);
+        const r = await fetch("/api/insights", { cache: "no-store" });
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        setData(await r.json());
+      } catch (e: any) {
+        setErr(e?.message ?? "Failed to load");
+      }
+    }
+    load();
+  }, []);
+
+  const chartData = {
+    labels: ["Plants", "Tasks"],
+    datasets: [
+      {
+        label: "Count",
+        data: data ? [data.plantCount, data.taskCount] : [0, 0],
+        backgroundColor: ["#86efac", "#93c5fd"],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <section className="mt-4 space-y-6">
+        <h2 className="text-sm font-display font-medium text-neutral-600">Insights</h2>
+
+        {err && (
+          <div className="rounded-xl border bg-white shadow-sm p-4 text-sm text-red-600">
+            {err}
+          </div>
+        )}
+
+        {!data && !err && <div className="text-sm text-neutral-500">Loading…</div>}
+
+        {data && (
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+                <div className="text-sm text-neutral-500">Plants</div>
+                <div className="text-2xl font-bold">{data.plantCount}</div>
+              </div>
+              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+                <div className="text-sm text-neutral-500">Tasks</div>
+                <div className="text-2xl font-bold">{data.taskCount}</div>
+              </div>
+            </div>
+            <div className="rounded-xl border bg-white shadow-sm p-4">
+              <div className="h-48">
+                <Bar
+                  data={chartData}
+                  options={{
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false } },
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+      <BottomNav value="insights" />
+    </>
+  );
+}
+

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,8 +1,8 @@
 "use client";
 import * as React from "react";
+import Link from "next/link";
 
 import { Leaf, Sprout, BarChart3, Cog, History } from "lucide-react";
-
 
 export type Tab = "today" | "timeline" | "plants" | "insights" | "settings";
 
@@ -11,26 +11,49 @@ export default function BottomNav({
   onChange,
 }: {
   value: Tab;
-  onChange: (t: Tab) => void;
+  onChange?: (t: Tab) => void;
 }) {
+  const paths: Record<Tab, string> = {
+    today: "/app?tab=today",
+    timeline: "/app?tab=timeline",
+    plants: "/app?tab=plants",
+    insights: "/app/insights",
+    settings: "/app?tab=settings",
+  };
+
   const Item = ({
     tab,
     label,
     icon,
+    href,
   }: {
     tab: Tab;
     label: string;
     icon: React.ReactNode;
+    href?: string;
   }) => {
     const active = value === tab;
+    const className = `py-3 flex flex-col items-center justify-center text-xs ${
+      active
+        ? "text-neutral-900 dark:text-neutral-100"
+        : "text-neutral-600 dark:text-neutral-400"
+    }`;
+
+    if (href) {
+      return (
+        <Link href={href} className={className} aria-current={active ? "page" : undefined}>
+          <div className={`mb-1 ${active ? "" : "opacity-80"}`}>{icon}</div>
+          <span className="font-sans">{label}</span>
+          {active && (
+            <span className="mt-1 h-1 w-6 rounded-full bg-neutral-900 dark:bg-neutral-100" />
+          )}
+        </Link>
+      );
+    }
     return (
       <button
-        onClick={() => onChange(tab)}
-        className={`py-3 flex flex-col items-center justify-center text-xs ${
-          active
-            ? "text-neutral-900 dark:text-neutral-100"
-            : "text-neutral-600 dark:text-neutral-400"
-        }`}
+        onClick={() => onChange?.(tab)}
+        className={className}
         aria-current={active ? "page" : undefined}
       >
         <div className={`mb-1 ${active ? "" : "opacity-80"}`}>{icon}</div>
@@ -48,13 +71,11 @@ export default function BottomNav({
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="max-w-screen-sm mx-auto grid grid-cols-5">
-
-        <Item tab="today" label="Today" icon={<Leaf />} />
-        <Item tab="timeline" label="Timeline" icon={<History />} />
-        <Item tab="plants" label="Plants" icon={<Sprout />} />
-        <Item tab="insights" label="Insights" icon={<BarChart3 />} />
-        <Item tab="settings" label="Settings" icon={<Cog />} />
-
+        <Item tab="today" label="Today" icon={<Leaf />} href={!onChange ? paths.today : undefined} />
+        <Item tab="timeline" label="Timeline" icon={<History />} href={!onChange ? paths.timeline : undefined} />
+        <Item tab="plants" label="Plants" icon={<Sprout />} href={!onChange ? paths.plants : undefined} />
+        <Item tab="insights" label="Insights" icon={<BarChart3 />} href={paths.insights} />
+        <Item tab="settings" label="Settings" icon={<Cog />} href={!onChange ? paths.settings : undefined} />
       </div>
     </nav>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@prisma/client": "^6.14.0",
         "@supabase/supabase-js": "^2.55.0",
+        "chart.js": "^4.5.0",
         "framer-motion": "^11.0.0",
         "lucide-react": "^0.452.0",
         "next": "latest",
         "next-themes": "^0.2.1",
         "openai": "^4.104.0",
         "react": "18.2.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
@@ -551,6 +553,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "15.4.6",
@@ -1335,6 +1343,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2931,6 +2951,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   "dependencies": {
     "@prisma/client": "^6.14.0",
     "@supabase/supabase-js": "^2.55.0",
+    "chart.js": "^4.5.0",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.452.0",
     "next": "latest",
     "next-themes": "^0.2.1",
     "openai": "^4.104.0",
     "react": "18.2.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- build insights page that fetches `/api/insights` and renders metrics with a bar chart
- link bottom navigation to insights and support link-based navigation
- add Chart.js for simple visualizations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a293bd07e08324a02d69a6ca1d7744