### PR TITLE
feat: migrate plants and tasks to supabase

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -1,9 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { listPlants, createPlant } from "@/lib/mockdb";
+import { createRouteHandlerClient } from "@/lib/supabase";
 
 export async function GET() {
   try {
-    return NextResponse.json(listPlants());
+    const supabase = await createRouteHandlerClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user)
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+    const { data, error } = await supabase
+      .from("plants")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("name");
+    if (error) throw error;
+    return NextResponse.json(data);
   } catch (e: any) {
     console.error("GET /api/plants failed:", e);
     return NextResponse.json({ error: "server" }, { status: 500 });
@@ -12,24 +26,30 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createRouteHandlerClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user)
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
     const body = await req.json().catch(() => ({}));
-    const created = createPlant({
-      name: body?.name || "New Plant",
-      roomId: body?.room ?? body?.roomId,
-      species: body?.species,
-      potSize: body?.potSize,
-      potMaterial: body?.potMaterial,
-      soilType: body?.soilType,
-      rules: Array.isArray(body?.rules)
-        ? body.rules.map((r: any) => ({
-            type: r?.type,
-            intervalDays: Number(r?.intervalDays) || 0,
-            amountMl: r?.amountMl,
-            formula: r?.formula,
-          }))
-        : undefined,
-    });
-    return NextResponse.json(created, { status: 201 });
+    const { data, error } = await supabase
+      .from("plants")
+      .insert({
+        user_id: user.id,
+        name: body?.name || "New Plant",
+        room_id: body?.room ?? body?.roomId,
+        species: body?.species,
+        pot_size: body?.potSize,
+        pot_material: body?.potMaterial,
+        soil_type: body?.soilType,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    return NextResponse.json(data, { status: 201 });
   } catch (e: any) {
     console.error("POST /api/plants failed:", e);
     return NextResponse.json({ error: "server" }, { status: 500 });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,22 +1,88 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getTasks, createTask } from "@/lib/mockdb";
+import { createRouteHandlerClient } from "@/lib/supabase";
 
 export async function GET(req: NextRequest) {
+  const supabase = await createRouteHandlerClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user)
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
   const url = new URL(req.url);
   const win = url.searchParams.get("window") || "7d";
   const days = Number(win.replace("d", "")) || 7;
-  return NextResponse.json(getTasks(days));
+  const maxDate = new Date();
+  maxDate.setDate(maxDate.getDate() + days);
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("id, type, due_at, plant:plants(id, name, room_id)")
+    .eq("user_id", user.id)
+    .lte("due_at", maxDate.toISOString())
+    .order("due_at");
+  if (error) {
+    console.error("GET /api/tasks failed:", error);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+
+  const tasks = (data || []).map((t: any) => ({
+    id: t.id,
+    plantId: t.plant?.id ?? t.plant_id,
+    plantName: t.plant?.name ?? "",
+    roomId: t.plant?.room_id ?? "",
+    type: t.type,
+    dueAt: t.due_at,
+    status: "due",
+    lastEventAt: null,
+  }));
+
+  return NextResponse.json(tasks);
 }
 
 export async function POST(req: NextRequest) {
+  const supabase = await createRouteHandlerClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user)
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
   const body = await req.json().catch(() => ({}));
-  // payload: { plant, action: "Water"|"Fertilize"|"Repot", due }
   const action = String(body.action || "Water").toLowerCase();
-  const rec = createTask({
-    plantId: body.plantId || "p1",
-    plantName: body.plant || "New Plant",
-    type: action === "water" ? "water" : action === "fertilize" ? "fertilize" : "repot",
-    dueAt: new Date().toISOString(),
-  });
+  const plantId = body.plantId;
+  if (!plantId) {
+    return NextResponse.json({ error: "plantId required" }, { status: 400 });
+  }
+  const type = action === "water" ? "water" : action === "fertilize" ? "fertilize" : "repot";
+  const dueAt = body.dueAt || new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .insert({
+      user_id: user.id,
+      plant_id: plantId,
+      type,
+      due_at: dueAt,
+    })
+    .select("id, type, due_at, plant:plants(id, name, room_id)")
+    .single();
+  if (error) {
+    console.error("POST /api/tasks failed:", error);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+
+  const rec = {
+    id: data.id,
+    plantId: data.plant?.id ?? plantId,
+    plantName: data.plant?.name ?? "",
+    roomId: data.plant?.room_id ?? "",
+    type: data.type,
+    dueAt: data.due_at,
+    status: "due",
+    lastEventAt: null,
+  };
   return NextResponse.json(rec, { status: 201 });
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,32 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
+import type { Database } from './supabase.types';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+// Factory for an unauthenticated client
+export function createSupabaseClient(): SupabaseClient<Database> {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+// Authenticated client helper for Route Handlers
+export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('sb-access-token')?.value;
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      global: {
+        headers: {
+          Authorization: accessToken ? `Bearer ${accessToken}` : '',
+        },
+      },
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    },
+  );
+}

--- a/lib/supabase.types.ts
+++ b/lib/supabase.types.ts
@@ -1,0 +1,104 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      plants: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          room_id: string | null;
+          species: string | null;
+          pot_size: string | null;
+          pot_material: string | null;
+          soil_type: string | null;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          room_id?: string | null;
+          species?: string | null;
+          pot_size?: string | null;
+          pot_material?: string | null;
+          soil_type?: string | null;
+          created_at?: string | null;
+        };
+        Update: {
+          name?: string;
+          room_id?: string | null;
+          species?: string | null;
+          pot_size?: string | null;
+          pot_material?: string | null;
+          soil_type?: string | null;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "plants_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      tasks: {
+        Row: {
+          id: string;
+          user_id: string;
+          plant_id: string;
+          type: string;
+          due_at: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          plant_id: string;
+          type: string;
+          due_at: string;
+          created_at?: string | null;
+        };
+        Update: {
+          type?: string;
+          due_at?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "tasks_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "tasks_plant_id_fkey";
+            columns: ["plant_id"];
+            referencedRelation: "plants";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+}

--- a/supabase/migrations/0001_plants_tasks.sql
+++ b/supabase/migrations/0001_plants_tasks.sql
@@ -1,0 +1,32 @@
+-- Supabase migration to create plants and tasks tables
+create table if not exists public.plants (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  room_id text,
+  species text,
+  pot_size text,
+  pot_material text,
+  soil_type text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  plant_id uuid not null references public.plants(id) on delete cascade,
+  type text not null,
+  due_at timestamptz not null,
+  created_at timestamptz default now()
+);
+
+-- Enable Row Level Security
+alter table public.plants enable row level security;
+alter table public.tasks enable row level security;
+
+-- Policies to ensure users can only access their own data
+create policy "Plants are user specific" on public.plants
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "Tasks are user specific" on public.tasks
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- define plants and tasks tables with RLS policies in Supabase
- generate TypeScript types and authenticated client helpers
- replace mockdb usage in plant and task APIs with Supabase queries

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a293a394cc8324b8315fd65dbf3a44