### PR TITLE
Use Unsplash for mock plant photos

### DIFF
--- a/docs/sample-images.md
+++ b/docs/sample-images.md
@@ -1,0 +1,24 @@
+# Sample Plant Images
+
+Seed data uses photos sourced from [Unsplash](https://unsplash.com/) via the [Source API](https://source.unsplash.com/).
+Each entry in `mock/plants.ts` points to a URL like:
+
+```
+https://source.unsplash.com/600x400/?snake-plant
+```
+
+The query portion (`snake-plant` above) corresponds to the plant's common name. Unsplash returns a real photograph matching the
+query which is used as the placeholder image in development.
+
+## Regenerating locally
+
+If the images change or you need local copies, run the helper script:
+
+```bash
+npm run sample-images
+```
+
+This downloads the current Unsplash images into `public/sample-images/`. You can then upload them to your own
+Supabase storage using `lib/storage.ts`'s `uploadPlantPhoto` function and replace the URLs in the seed files with the
+returned public URLs.
+

--- a/mock/plants.ts
+++ b/mock/plants.ts
@@ -18,7 +18,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2024-03-01",
-    photos: ["https://placehold.co/600x400?text=Fiddle"],
+    photos: ["https://source.unsplash.com/600x400/?fiddle-leaf-fig"],
     notes: [],
   },
   {
@@ -40,7 +40,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Cactus mix",
     acquiredAt: "2023-11-12",
-    photos: ["https://placehold.co/600x400?text=Snake"],
+    photos: ["https://source.unsplash.com/600x400/?snake-plant"],
     notes: [],
   },
   {
@@ -62,7 +62,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Potting mix",
     acquiredAt: "2024-01-15",
-    photos: ["https://placehold.co/600x400?text=Spider"],
+    photos: ["https://source.unsplash.com/600x400/?spider-plant"],
     notes: [],
   },
   {
@@ -84,7 +84,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "All-purpose mix",
     acquiredAt: "2024-02-10",
-    photos: ["https://placehold.co/600x400?text=Pothos"],
+    photos: ["https://source.unsplash.com/600x400/?pothos"],
     notes: [],
   },
   {
@@ -106,7 +106,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Moisture-retentive mix",
     acquiredAt: "2024-04-05",
-    photos: ["https://placehold.co/600x400?text=PeaceLily"],
+    photos: ["https://source.unsplash.com/600x400/?peace-lily"],
     notes: [],
   },
   {
@@ -128,7 +128,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2023-09-20",
-    photos: ["https://placehold.co/600x400?text=ZZ"],
+    photos: ["https://source.unsplash.com/600x400/?zz-plant"],
     notes: [],
   },
   {
@@ -150,7 +150,7 @@ export const mockPlants = [
     potMaterial: "Terracotta",
     soilType: "Cactus mix",
     acquiredAt: "2024-05-20",
-    photos: ["https://placehold.co/600x400?text=Aloe"],
+    photos: ["https://source.unsplash.com/600x400/?aloe-vera"],
     notes: [],
   },
   {
@@ -172,7 +172,7 @@ export const mockPlants = [
     potMaterial: "Hanging basket",
     soilType: "Peat-based mix",
     acquiredAt: "2024-06-12",
-    photos: ["https://placehold.co/600x400?text=Fern"],
+    photos: ["https://source.unsplash.com/600x400/?boston-fern"],
     notes: [],
   },
   {
@@ -194,7 +194,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2024-03-18",
-    photos: ["https://placehold.co/600x400?text=Rubber"],
+    photos: ["https://source.unsplash.com/600x400/?rubber-plant"],
     notes: [],
   },
   {
@@ -216,7 +216,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Potting mix",
     acquiredAt: "2024-02-25",
-    photos: ["https://placehold.co/600x400?text=Philodendron"],
+    photos: ["https://source.unsplash.com/600x400/?philodendron"],
     notes: [],
   },
   {
@@ -238,7 +238,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2024-01-30",
-    photos: ["https://placehold.co/600x400?text=Aglaonema"],
+    photos: ["https://source.unsplash.com/600x400/?chinese-evergreen"],
     notes: [],
   },
   {
@@ -260,7 +260,7 @@ export const mockPlants = [
     potMaterial: "Terracotta",
     soilType: "Cactus mix",
     acquiredAt: "2023-12-05",
-    photos: ["https://placehold.co/600x400?text=Jade"],
+    photos: ["https://source.unsplash.com/600x400/?jade-plant"],
     notes: [],
   },
   {
@@ -282,7 +282,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Aroid mix",
     acquiredAt: "2024-05-01",
-    photos: ["https://placehold.co/600x400?text=Monstera"],
+    photos: ["https://source.unsplash.com/600x400/?monstera"],
     notes: [],
   },
   {
@@ -304,7 +304,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Potting mix",
     acquiredAt: "2024-03-14",
-    photos: ["https://placehold.co/600x400?text=Ivy"],
+    photos: ["https://source.unsplash.com/600x400/?english-ivy"],
     notes: [],
   },
   {
@@ -326,7 +326,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Peat-based mix",
     acquiredAt: "2024-02-28",
-    photos: ["https://placehold.co/600x400?text=ParlorPalm"],
+    photos: ["https://source.unsplash.com/600x400/?parlor-palm"],
     notes: [],
   },
   {
@@ -348,7 +348,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2024-04-18",
-    photos: ["https://placehold.co/600x400?text=MoneyTree"],
+    photos: ["https://source.unsplash.com/600x400/?money-tree"],
     notes: [],
   },
   {
@@ -370,7 +370,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Well-draining mix",
     acquiredAt: "2024-03-08",
-    photos: ["https://placehold.co/600x400?text=Croton"],
+    photos: ["https://source.unsplash.com/600x400/?croton-plant"],
     notes: [],
   },
   {
@@ -392,7 +392,7 @@ export const mockPlants = [
     potMaterial: "Ceramic",
     soilType: "Well-draining mix",
     acquiredAt: "2023-10-10",
-    photos: ["https://placehold.co/600x400?text=Dracaena"],
+    photos: ["https://source.unsplash.com/600x400/?dracaena"],
     notes: [],
   },
   {
@@ -414,7 +414,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "Orchid bark",
     acquiredAt: "2024-07-07",
-    photos: ["https://placehold.co/600x400?text=Orchid"],
+    photos: ["https://source.unsplash.com/600x400/?orchid"],
     notes: [],
   },
   {
@@ -436,7 +436,7 @@ export const mockPlants = [
     potMaterial: "Plastic",
     soilType: "African violet mix",
     acquiredAt: "2024-06-22",
-    photos: ["https://placehold.co/600x400?text=Violet"],
+    photos: ["https://source.unsplash.com/600x400/?african-violet"],
     notes: [],
   }
 ];

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
     "ai:fine-tune": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/fine-tune.ts",
-    "test": "jest"
+    "test": "jest",
+    "sample-images": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/fetch-sample-images.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",

--- a/scripts/fetch-sample-images.ts
+++ b/scripts/fetch-sample-images.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+
+const plants = [
+  { id: "p1", query: "fiddle-leaf-fig" },
+  { id: "p2", query: "snake-plant" },
+  { id: "p3", query: "spider-plant" },
+  { id: "p4", query: "pothos" },
+  { id: "p5", query: "peace-lily" },
+  { id: "p6", query: "zz-plant" },
+  { id: "p7", query: "aloe-vera" },
+  { id: "p8", query: "boston-fern" },
+  { id: "p9", query: "rubber-plant" },
+  { id: "p10", query: "philodendron" },
+  { id: "p11", query: "chinese-evergreen" },
+  { id: "p12", query: "jade-plant" },
+  { id: "p13", query: "monstera" },
+  { id: "p14", query: "english-ivy" },
+  { id: "p15", query: "parlor-palm" },
+  { id: "p16", query: "money-tree" },
+  { id: "p17", query: "croton-plant" },
+  { id: "p18", query: "dracaena" },
+  { id: "p19", query: "orchid" },
+  { id: "p20", query: "african-violet" },
+];
+
+async function main() {
+  const outDir = path.join(__dirname, "..", "public", "sample-images");
+  await fs.promises.mkdir(outDir, { recursive: true });
+
+  for (const plant of plants) {
+    const url = `https://source.unsplash.com/600x400/?${plant.query}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`Failed to fetch ${url}: ${res.status}`);
+      continue;
+    }
+    const arrayBuffer = await res.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const filePath = path.join(outDir, `${plant.id}.jpg`);
+    await fs.promises.writeFile(filePath, buffer);
+    console.log(`saved ${filePath}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- replace placeholder photo URLs with Unsplash Source queries
- document where sample plant images come from and how to refresh them
- add helper script to download sample images

## Testing
- `npm test` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run sample-images` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a29cb96fc48324992d5eccc28424ce