### PR TITLE
feat: add single user mode to tasks API

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,3 +5,5 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 DATABASE_URL="postgresql://user:password@host:5432/dbname"
 NEXT_PUBLIC_TASK_WINDOW_DAYS=7
 OPENAI_API_KEY=your-openai-api-key
+SINGLE_USER_MODE=false
+SINGLE_USER_ID=your-user-id

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
    - `DATABASE_URL` is used by Prisma; the example file defaults to a local SQLite database.
    - `NEXT_PUBLIC_TASK_WINDOW_DAYS` controls how many days ahead the Upcoming view looks (default `7`).
    - `OPENAI_API_KEY` enables AI-powered care recommendations.
+   - `SINGLE_USER_MODE` set to `true` to bypass Supabase auth.
+   - `SINGLE_USER_ID` the user ID used when `SINGLE_USER_MODE` is enabled.
 3. Run migrations, seed the database, and start the development server:
    ```bash
    npm run db:migrate
@@ -32,6 +34,10 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
    npm run dev
    # open http://localhost:3000/app
    ```
+
+### Single-User Mode
+
+For testing or a single-user deployment, enable `SINGLE_USER_MODE` and set `SINGLE_USER_ID`. When enabled, API routes such as `/api/tasks` skip Supabase authentication and operate on the fixed user ID.
 
 To create a production build run:
 ```bash


### PR DESCRIPTION
## Summary
- allow bypassing Supabase auth for `/api/tasks` via `SINGLE_USER_MODE`
- document `SINGLE_USER_MODE` and `SINGLE_USER_ID`
- add example env vars for single-user mode

## Testing
- `npm test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a7b6a3e88324acbc73c8f0de5272