### PR TITLE
Fix URL header parsing on app page

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,9 +1,9 @@
 import { headers } from "next/headers";
 import AppShell from "./AppShell";
 
-export default async function Page() {
-  const h = await headers();
-  const searchParams = new URLSearchParams(h.get("x-url")?.split("?")[1]);
+export default function Page() {
+  const url = headers().get("x-url");
+  const searchParams = new URLSearchParams(url?.split("?")[1] || "");
   const tab = searchParams.get("tab") ?? "today";
-  return <AppShell initialView={tab as "today"|"timeline"|"plants"|"insights"|"settings"} />;
+  return <AppShell initialView={tab as "today" | "timeline" | "plants" | "insights" | "settings"} />;
 }


### PR DESCRIPTION
## Summary
- Simplify app page to synchronously read headers
- Handle missing `x-url` header when parsing search parameters

## Testing
- `npm test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ac2f8ef48324a6ee24978e9b7055