### PR TITLE
Use .env for configuration and document single-user setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Rename this file to .env.local and populate with your own values
+# Rename this file to .env and populate with your own values
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 # .gitignore
 .next
 node_modules
-.env.local
 .DS_Store
-.env.local
-.env.local
 .env
+.env.local
 fine-tune-data.jsonl
 .vercel

--- a/README.md
+++ b/README.md
@@ -37,7 +37,20 @@ Whether you're nurturing one plant or a hundred, Kay Maria adapts to your space,
 
 ### Single-User Mode
 
-For testing or a single-user deployment, enable `SINGLE_USER_MODE` and set `SINGLE_USER_ID`. When enabled, API routes such as `/api/tasks` skip Supabase authentication and operate on the fixed user ID.
+To run the app without signing in, configure a fixed Supabase user ID:
+
+1. **Create a Supabase user**
+   - Dashboard → **Authentication → Users → Add User**.
+   - Copy the generated UUID from the **ID** column.
+2. **Fill out the `.env` file**
+   - `SINGLE_USER_MODE=true`
+   - `SINGLE_USER_ID=<copied UUID>`
+   - ensure the other Supabase variables are populated.
+3. **Restart the dev server**
+   ```bash
+   npm run dev
+   ```
+4. Visit [http://localhost:3000/app](http://localhost:3000/app); API routes will use the fixed user ID and skip authentication.
 
 To create a production build run:
 ```bash
@@ -123,15 +136,28 @@ To view a live preview of the design tokens and color palette in the app, visit:
 
 ## ☁️ Deployment
 
-Deploy the app to [Vercel](https://vercel.com/) with the Vercel CLI:
+Deploy to [Vercel](https://vercel.com):
 
-```bash
-npm install -g vercel
-vercel
-vercel --prod
-```
+1. **Push** this repository to GitHub (or another Git provider).
+2. **Create a Vercel project** and link it to the repo.
+3. **Add environment variables** in *Project Settings → Environment Variables*:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `NEXT_PUBLIC_BASE_URL=https://kaymaria.vercel.app`
+   - `DATABASE_URL`
+   - `NEXT_PUBLIC_TASK_WINDOW_DAYS`
+   - `OPENAI_API_KEY` *(optional)*
+   - `SINGLE_USER_MODE=true`
+   - `SINGLE_USER_ID=<same UUID used locally>`
+4. **Deploy**
+   ```bash
+   npm install -g vercel
+   vercel
+   vercel --prod
+   ```
+5. Visit [https://kaymaria.vercel.app/app](https://kaymaria.vercel.app/app) to confirm everything is working.
 
-The included [`vercel.json`](./vercel.json) maps required environment variables to your project settings.
+The included [`vercel.json`](./vercel.json) ensures Vercel picks up the required environment variables.
 
 ## 🔌 Test API
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -4,7 +4,7 @@ This project uses [Prisma](https://www.prisma.io/) with a PostgreSQL database.
 
 ## Setup
 
-1. Copy `.env.local.example` to `.env.local` and set `DATABASE_URL` to point to your local PostgreSQL instance.
+1. Copy `.env.example` to `.env` and set `DATABASE_URL` to point to your local PostgreSQL instance.
 2. Install dependencies:
    ```bash
    npm install

--- a/docs/roadmaps/roadmap-v1.md
+++ b/docs/roadmaps/roadmap-v1.md
@@ -7,7 +7,7 @@ All items are **unchecked** to indicate upcoming work.
 
 ## Phase 0 – Foundation
 
- - [x] Set up Supabase project and env keys (.env.local)
+ - [x] Set up Supabase project and env keys (.env)
  - [x] Run database migrations (Prisma)
  - [x] Create seed scripts for mock data (plants, tasks)
  - [x] Add test route to fetch plants and tasks


### PR DESCRIPTION
## Summary
- rename `.env.local.example` to `.env.example` and update instructions
- document single-user mode and Vercel deployment in README
- clean up `.gitignore` and docs referencing `.env.local`

## Testing
- `npm test` *(fails: Can't reach database server at localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a323eff5ec8324995ea4ba45625907