### PR TITLE
feat: add species autosuggest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 DATABASE_URL="postgresql://user:password@host:5432/dbname"
 NEXT_PUBLIC_TASK_WINDOW_DAYS=7
 OPENAI_API_KEY=your-openai-api-key
+TREFLE_API_TOKEN=your-trefle-api-token
 SINGLE_USER_MODE=false
 SINGLE_USER_ID=your-user-id

--- a/app/api/species-search/route.test.ts
+++ b/app/api/species-search/route.test.ts
@@ -17,4 +17,28 @@ describe('GET /api/species-search', () => {
     const json = await res.json();
     expect(json).toEqual([]);
   });
+
+  it('queries Trefle when token present', async () => {
+    const oldFetch = global.fetch;
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ common_name: 'Rose', scientific_name: 'Rosa rubiginosa' }],
+      }),
+    } as any);
+    (global as any).fetch = mockFetch;
+    process.env.TREFLE_API_TOKEN = 'token';
+
+    const req = new Request('http://localhost/api/species-search?q=rose');
+    const res = await GET(req as any);
+    const json = await res.json();
+
+    expect(mockFetch).toHaveBeenCalled();
+    expect(json).toEqual([
+      { name: 'Rose', species: 'Rosa rubiginosa' },
+    ]);
+
+    delete process.env.TREFLE_API_TOKEN;
+    (global as any).fetch = oldFetch;
+  });
 });

--- a/app/api/species-search/route.test.ts
+++ b/app/api/species-search/route.test.ts
@@ -1,0 +1,20 @@
+import { GET } from './route';
+
+describe('GET /api/species-search', () => {
+  it('returns matching species', async () => {
+    const req = new Request('http://localhost/api/species-search?q=fic');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect(json.some((s: any) => s.species.toLowerCase().includes('fic'))).toBe(true);
+  });
+
+  it('returns empty array for empty query', async () => {
+    const req = new Request('http://localhost/api/species-search?q=');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+});

--- a/app/api/species-search/route.ts
+++ b/app/api/species-search/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SPECIES } from '@/lib/species';
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const q = (searchParams.get('q') || '').trim().toLowerCase();
+    if (!q) {
+      return NextResponse.json([]);
+    }
+    const matches = SPECIES.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.species.toLowerCase().includes(q)
+    ).slice(0, 10);
+    return NextResponse.json(matches);
+  } catch (e) {
+    console.error('GET /api/species-search failed:', e);
+    return NextResponse.json({ error: 'server' }, { status: 500 });
+  }
+}

--- a/app/api/species-search/route.ts
+++ b/app/api/species-search/route.ts
@@ -1,19 +1,48 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { SPECIES } from '@/lib/species';
+import { SPECIES, SpeciesRecord } from '@/lib/species';
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const q = (searchParams.get('q') || '').trim().toLowerCase();
+    const q = (searchParams.get('q') || '').trim();
     if (!q) {
       return NextResponse.json([]);
     }
-    const matches = SPECIES.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) ||
-        s.species.toLowerCase().includes(q)
-    ).slice(0, 10);
-    return NextResponse.json(matches);
+
+    let results: SpeciesRecord[] = [];
+    const token = process.env.TREFLE_API_TOKEN;
+
+    if (token) {
+      try {
+        const res = await fetch(
+          `https://trefle.io/api/v1/plants/search?q=${encodeURIComponent(q)}&token=${token}`
+        );
+        if (res.ok) {
+          const json = await res.json();
+          results = (json.data || [])
+            .slice(0, 10)
+            .map((p: any) => ({
+              name: p.common_name || p.scientific_name,
+              species: p.scientific_name,
+            }));
+        } else {
+          console.error('Trefle API error', res.status);
+        }
+      } catch (err) {
+        console.error('Trefle API request failed', err);
+      }
+    }
+
+    if (!results.length) {
+      const qLower = q.toLowerCase();
+      results = SPECIES.filter(
+        (s) =>
+          s.name.toLowerCase().includes(qLower) ||
+          s.species.toLowerCase().includes(qLower)
+      ).slice(0, 10);
+    }
+
+    return NextResponse.json(results);
   } catch (e) {
     console.error('GET /api/species-search failed:', e);
     return NextResponse.json({ error: 'server' }, { status: 500 });

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { fetchCareRules, CareSuggest } from '@/lib/careRules';
+import SpeciesAutosuggest from './SpeciesAutosuggest';
 
 export type PlantFormValues = {
   name: string;
@@ -154,11 +155,10 @@ export default function PlantForm({
     <>
       <div className="p-5 space-y-4">
         <Field label="Name">
-          <input
-            className="input"
+          <SpeciesAutosuggest
             value={state.name}
-            onChange={(e) => setState({ ...state, name: e.target.value })}
-            placeholder="e.g., Monstera Deliciosa"
+            onChange={(v) => setState({ ...state, name: v })}
+            onSelect={(s) => setState({ ...state, name: s.name, species: s.species })}
           />
         </Field>
 
@@ -169,14 +169,6 @@ export default function PlantForm({
             onChange={(e) => setState({ ...state, roomId: e.target.value })}
           />
           <p className="hint">Stored locally in Settings → Defaults.</p>
-        </Field>
-
-        <Field label="Species (optional)">
-          <input
-            className="input"
-            value={state.species}
-            onChange={(e) => setState({ ...state, species: e.target.value })}
-          />
         </Field>
 
         <div className="grid grid-cols-3 gap-3">

--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+type Suggestion = {
+  name: string;
+  species: string;
+};
+
+export default function SpeciesAutosuggest({
+  value,
+  onChange,
+  onSelect,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSelect: (s: Suggestion) => void;
+}) {
+  const [query, setQuery] = useState(value);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    async function load() {
+      try {
+        const r = await fetch(`/api/species-search?q=${encodeURIComponent(query)}`, { signal: controller.signal });
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const json = await r.json();
+        setSuggestions(json);
+        setOpen(true);
+      } catch (e) {
+        if ((e as any).name !== 'AbortError') {
+          console.error('species search failed', e);
+        }
+      }
+    }
+    load();
+    return () => controller.abort();
+  }, [query]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setQuery(v);
+    onChange(v);
+  }
+
+  function choose(item: Suggestion) {
+    onSelect(item);
+    setQuery(item.name);
+    onChange(item.name);
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative">
+      <input
+        className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-neutral-300"
+        value={query}
+        onChange={handleChange}
+        onFocus={() => { if (suggestions.length) setOpen(true); }}
+        onBlur={() => setTimeout(() => setOpen(false), 100)}
+        placeholder="e.g., Monstera"
+      />
+      {open && suggestions.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-full bg-white border rounded-lg shadow">
+          {suggestions.map((s) => (
+            <li
+              key={s.species}
+              className="px-3 py-2 text-sm cursor-pointer hover:bg-neutral-100"
+              onMouseDown={(e) => { e.preventDefault(); choose(s); }}
+            >
+              <div className="font-medium">{s.name}</div>
+              <div className="text-xs text-neutral-500">{s.species}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lib/species.ts
+++ b/lib/species.ts
@@ -1,0 +1,17 @@
+export type SpeciesRecord = {
+  name: string;
+  species: string;
+};
+
+export const SPECIES: SpeciesRecord[] = [
+  { name: 'Fiddle Leaf Fig', species: 'Ficus lyrata' },
+  { name: 'Monstera', species: 'Monstera deliciosa' },
+  { name: 'Snake Plant', species: 'Sansevieria trifasciata' },
+  { name: 'ZZ Plant', species: 'Zamioculcas zamiifolia' },
+  { name: 'Peace Lily', species: 'Spathiphyllum wallisii' },
+  { name: 'Aloe Vera', species: 'Aloe vera' },
+  { name: 'Boston Fern', species: 'Nephrolepis exaltata' },
+  { name: 'Spider Plant', species: 'Chlorophytum comosum' },
+  { name: 'Pothos', species: 'Epipremnum aureum' },
+  { name: 'Rubber Plant', species: 'Ficus elastica' },
+];


### PR DESCRIPTION
## Summary
- implement `/api/species-search` endpoint returning species matches
- add `SpeciesAutosuggest` component for plant name/species lookup
- integrate autosuggest into `PlantForm` and populate species

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3728d240c8324956b182c3bf53cfa