### PR TITLE
feat: add room selector and rooms API

### DIFF
--- a/app/api/rooms/route.test.ts
+++ b/app/api/rooms/route.test.ts
@@ -1,0 +1,59 @@
+import { GET, POST } from './route';
+import { createRouteHandlerClient } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  createRouteHandlerClient: jest.fn(),
+}));
+
+describe('GET/POST /api/rooms', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns rooms', async () => {
+    const rooms = [{ id: 'r1', name: 'Living' }];
+    const mockFrom = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockResolvedValue({ data: rooms, error: null }),
+    });
+    const mockSupabase: any = {
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }) },
+      from: mockFrom,
+    };
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue(mockSupabase);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual(rooms);
+    expect(mockFrom).toHaveBeenCalledWith('rooms');
+  });
+
+  it('creates room', async () => {
+    const created = { id: 'r2', name: 'Bedroom' };
+    const mockFrom = jest.fn().mockReturnValue({
+      insert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: created, error: null }),
+      eq: jest.fn(),
+      order: jest.fn(),
+    });
+    const mockSupabase: any = {
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }) },
+      from: mockFrom,
+    };
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue(mockSupabase);
+
+    const req = new Request('http://localhost/api/rooms', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Bedroom' }),
+    });
+
+    const res = await POST(req as any);
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json).toEqual(created);
+    expect(mockFrom).toHaveBeenCalledWith('rooms');
+  });
+});

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase";
+
+export async function GET() {
+  try {
+    const supabase = await createRouteHandlerClient();
+    const singleUser = process.env.SINGLE_USER_MODE === "true";
+    let userId: string | undefined;
+    if (singleUser) {
+      userId = process.env.SINGLE_USER_ID;
+      if (!userId) {
+        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
+        return NextResponse.json({ error: "server" }, { status: 500 });
+      }
+    } else {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (userError || !user)
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      userId = user.id;
+    }
+
+    const { data, error } = await supabase
+      .from("rooms")
+      .select("id, name")
+      .eq("user_id", userId)
+      .order("name");
+    if (error) {
+      console.error("GET /api/rooms failed:", error);
+      return NextResponse.json({ error: "server" }, { status: 500 });
+    }
+    return NextResponse.json(data || []);
+  } catch (e: any) {
+    console.error("GET /api/rooms failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createRouteHandlerClient();
+    const singleUser = process.env.SINGLE_USER_MODE === "true";
+    let userId: string | undefined;
+    if (singleUser) {
+      userId = process.env.SINGLE_USER_ID;
+      if (!userId) {
+        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
+        return NextResponse.json({ error: "server" }, { status: 500 });
+      }
+    } else {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (userError || !user)
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      userId = user.id;
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const name = String(body.name || "").trim();
+    if (!name) return NextResponse.json({ error: "name required" }, { status: 400 });
+
+    const { data, error } = await supabase
+      .from("rooms")
+      .insert({ user_id: userId, name })
+      .select("id, name")
+      .single();
+    if (error) {
+      console.error("POST /api/rooms failed:", error);
+      return NextResponse.json({ error: "server" }, { status: 500 });
+    }
+    return NextResponse.json(data, { status: 201 });
+  } catch (e: any) {
+    console.error("POST /api/rooms failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { fetchCareRules, CareSuggest } from '@/lib/careRules';
+import RoomSelector from './RoomSelector';
 
 export type PlantFormValues = {
   name: string;
@@ -162,11 +163,10 @@ export default function PlantForm({
           />
         </Field>
 
-        <Field label="Room ID (internal)">
-          <input
-            className="input"
+        <Field label="Room">
+          <RoomSelector
             value={state.roomId}
-            onChange={(e) => setState({ ...state, roomId: e.target.value })}
+            onChange={(id) => setState({ ...state, roomId: id })}
           />
           <p className="hint">Stored locally in Settings → Defaults.</p>
         </Field>

--- a/components/RoomSelector.tsx
+++ b/components/RoomSelector.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React from 'react';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, useSelectCtx } from './ui/select';
+
+type Room = { id: string; name?: string };
+
+export default function RoomSelector({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (id: string) => void;
+}) {
+  const [rooms, setRooms] = React.useState<Room[]>([]);
+
+  React.useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/rooms');
+        if (res.ok) {
+          const json = await res.json();
+          setRooms(json);
+        }
+      } catch (e) {
+        console.error('Failed to load rooms', e);
+      }
+    }
+    load();
+  }, []);
+
+
+  async function handleAdd(ctx: ReturnType<typeof useSelectCtx>) {
+    if (!ctx) return;
+    const name = prompt('New room name');
+    if (!name) {
+      ctx.setOpen(false);
+      return;
+    }
+    try {
+      const res = await fetch('/api/rooms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      if (res.ok) {
+        const json: Room = await res.json();
+        setRooms((r) => [...r, json]);
+        onChange(json.id);
+        ctx.setSelectedLabel(json.name || json.id);
+      }
+    } catch (e) {
+      console.error('Failed to add room', e);
+    } finally {
+      ctx.setOpen(false);
+    }
+  }
+
+  function AddRoomItem() {
+    const ctx = useSelectCtx();
+    if (!ctx) return null;
+    return (
+      <button
+        type="button"
+        className="block w-full px-3 py-2 text-left text-sm hover:bg-neutral-100"
+        onClick={() => handleAdd(ctx)}
+      >
+        Add room
+      </button>
+    );
+  }
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger>
+        <SelectValue placeholder="Select room" />
+      </SelectTrigger>
+      <SelectContent>
+        {rooms.map((r) => (
+          <SelectItem key={r.id} value={r.id}>
+            {r.name || r.id}
+          </SelectItem>
+        ))}
+        <AddRoomItem />
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -13,6 +13,10 @@ type Ctx = {
 };
 const SelectCtx = React.createContext<Ctx | null>(null);
 
+export function useSelectCtx() {
+  return React.useContext(SelectCtx);
+}
+
 export function Select({
   value,
   onValueChange,


### PR DESCRIPTION
## Summary
- add rooms API with support for listing and creating rooms per user
- add RoomSelector component and use it in PlantForm
- export Select context hook for custom dropdown actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3749dbae883248e166ea2ecd043f7