### PR TITLE
Add AI-based care suggestions

### DIFF
--- a/app/api/ai-care/route.ts
+++ b/app/api/ai-care/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { suggestCare } from '@/lib/aiCare';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  try {
+    const suggestion = await suggestCare(body);
+    return NextResponse.json(suggestion);
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || 'Failed to generate suggestion' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/aiCare.ts
+++ b/lib/aiCare.ts
@@ -1,0 +1,65 @@
+import OpenAI from 'openai';
+
+export type AiCareParams = {
+  name?: string;
+  species?: string;
+  potSize?: string;
+  potMaterial?: string;
+  lat?: number;
+  lon?: number;
+};
+
+export type AiCareSuggestion = {
+  waterEvery: number;
+  waterAmount: number;
+  fertEvery: number;
+  fertFormula?: string;
+};
+
+export async function suggestCare({
+  name = 'Plant',
+  species = '',
+  potSize = '',
+  potMaterial = '',
+  lat,
+  lon,
+}: AiCareParams): Promise<AiCareSuggestion> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY not set');
+  }
+  const client = new OpenAI({ apiKey });
+
+  const location =
+    typeof lat === 'number' && typeof lon === 'number'
+      ? ` at latitude ${lat} and longitude ${lon}`
+      : '';
+
+  const prompt = `Suggest a simple care plan for a plant.\nName: ${name}\nSpecies: ${species}\nPot size: ${potSize}\nPot material: ${potMaterial}${location}\nReturn a JSON object with fields: waterEvery (days), waterAmount (ml), fertEvery (days), fertFormula (string).`;
+
+  const completion = await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a helpful plant care assistant that replies in JSON.',
+      },
+      { role: 'user', content: prompt },
+    ],
+    response_format: { type: 'json_object' },
+  });
+
+  const result = completion.choices[0]?.message?.content;
+  if (!result) {
+    throw new Error('No response from model');
+  }
+
+  const data = JSON.parse(result);
+  return {
+    waterEvery: data.waterEvery,
+    waterAmount: data.waterAmount,
+    fertEvery: data.fertEvery,
+    fertFormula: data.fertFormula,
+  };
+}
+


### PR DESCRIPTION
## Summary
- implement `lib/aiCare.suggestCare` to generate watering and fertilizer plans via OpenAI
- expose `/api/ai-care` POST endpoint returning AI care suggestions
- auto-fetch suggestions in plant form and let users accept or override them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3766a45fc8324b5568f6c578d5e84