### PR TITLE
Make root Page async

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,8 +1,9 @@
 import { headers } from "next/headers";
 import AppShell from "./AppShell";
 
-export default function Page() {
-  const url = headers().get("x-url");
+export default async function Page() {
+  const h = await headers();
+  const url = h.get("x-url");
   const searchParams = new URLSearchParams(url?.split("?")[1] || "");
   const tab = searchParams.get("tab") ?? "today";
   return <AppShell initialView={tab as "today" | "timeline" | "plants" | "insights" | "settings"} />;


### PR DESCRIPTION
## Summary
- make root page async and await headers to fetch x-url

## Testing
- `npm test`
- `npm run build` *(fails: Type error in app/api/plants/[id]/photos/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a37899541c8324a6394ce5d24507cc