### PR TITLE
Normalize species care lookup and expand defaults

### DIFF
--- a/lib/species-care.ts
+++ b/lib/species-care.ts
@@ -1,3 +1,11 @@
+/**
+ * Care defaults for supported plant species.
+ *
+ * To add a new species, append an entry to the `DEFAULTS` map with the
+ * botanical name in lowercase as the key. All properties defined in the
+ * `SpeciesCareDefaults` type must be provided so that lookups remain
+ * consistent.
+ */
 export type SpeciesCareDefaults = {
   pot: string;
   potMaterial: string;
@@ -12,7 +20,7 @@ export type SpeciesCareDefaults = {
 };
 
 const DEFAULTS: Record<string, SpeciesCareDefaults> = {
-  'Ficus lyrata': {
+  'ficus lyrata': {
     pot: '12 in',
     potMaterial: 'Ceramic',
     light: 'Bright indirect',
@@ -24,7 +32,7 @@ const DEFAULTS: Record<string, SpeciesCareDefaults> = {
     fertEvery: '30',
     fertFormula: '10-10-10 @ 1/2 strength',
   },
-  'Monstera deliciosa': {
+  'monstera deliciosa': {
     pot: '10 in',
     potMaterial: 'Plastic',
     light: 'Medium',
@@ -36,8 +44,47 @@ const DEFAULTS: Record<string, SpeciesCareDefaults> = {
     fertEvery: '30',
     fertFormula: '10-10-10 @ 1/2 strength',
   },
+  'zamioculcas zamiifolia': {
+    pot: '8 in',
+    potMaterial: 'Plastic',
+    light: 'Low to bright indirect',
+    indoor: 'Indoor',
+    drainage: 'ok',
+    soil: 'Well-draining mix',
+    waterEvery: '14',
+    waterAmount: '250',
+    fertEvery: '60',
+    fertFormula: '10-10-10 @ 1/2 strength',
+  },
+  'epipremnum aureum': {
+    pot: '6 in',
+    potMaterial: 'Plastic',
+    light: 'Low to medium',
+    indoor: 'Indoor',
+    drainage: 'ok',
+    soil: 'Well-draining mix',
+    waterEvery: '7',
+    waterAmount: '250',
+    fertEvery: '30',
+    fertFormula: '10-10-10 @ 1/2 strength',
+  },
+  'sansevieria trifasciata': {
+    pot: '8 in',
+    potMaterial: 'Terra cotta',
+    light: 'Low to bright indirect',
+    indoor: 'Indoor',
+    drainage: 'great',
+    soil: 'Succulent mix',
+    waterEvery: '21',
+    waterAmount: '250',
+    fertEvery: '60',
+    fertFormula: '10-10-10 @ 1/2 strength',
+  },
 };
 
-export async function getCareDefaults(species: string): Promise<SpeciesCareDefaults | null> {
-  return DEFAULTS[species] ?? null;
+export async function getCareDefaults(
+  species: string,
+): Promise<SpeciesCareDefaults | null> {
+  const key = species.trim().toLowerCase();
+  return DEFAULTS[key] ?? null;
 }


### PR DESCRIPTION
## Summary
- document process for adding plant species care defaults
- add common houseplant defaults and lowercase existing keys
- normalize species input before retrieving care defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37dbaf370832494c025de674d24d4