### PR TITLE
Gracefully handle missing species presets

### DIFF
--- a/app/api/species-care/route.ts
+++ b/app/api/species-care/route.ts
@@ -7,9 +7,9 @@ export async function GET(req: NextRequest) {
     const species = searchParams.get('species') || '';
     const defaults = await getCareDefaults(species);
     if (!defaults) {
-      return NextResponse.json({ error: 'not found' }, { status: 404 });
+      return NextResponse.json({ presets: null });
     }
-    return NextResponse.json(defaults);
+    return NextResponse.json({ presets: defaults });
   } catch (e: any) {
     console.error('GET /api/species-care failed:', e);
     return NextResponse.json({ error: 'server' }, { status: 500 });

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -22,6 +22,7 @@ export default function AddPlantModal({
   const [initial, setInitial] = useState<PlantFormValues | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   function close() {
     onOpenChange(false);
@@ -32,6 +33,7 @@ export default function AddPlantModal({
     async function loadDefaults() {
       setLoading(true);
       setLoadError(null);
+      setNotice(null);
       const base: PlantFormValues = {
         name: prefillName || '',
         roomId: defaultRoomId,
@@ -53,7 +55,12 @@ export default function AddPlantModal({
         const r = await fetch(`/api/species-care?species=${encodeURIComponent(prefillName || '')}`);
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         const json = await r.json();
-        setInitial({ ...base, ...json });
+        if (json.presets) {
+          setInitial({ ...base, ...json.presets });
+        } else {
+          setNotice('No presets found—please adjust manually or request AI suggestions');
+          setInitial(base);
+        }
       } catch (e) {
         setLoadError('Failed to load species defaults.');
         setInitial(base);
@@ -93,6 +100,9 @@ export default function AddPlantModal({
             <>
               {loadError && (
                 <div className="p-5 text-sm text-red-600">{loadError}</div>
+              )}
+              {notice && (
+                <div className="p-5 text-sm text-gray-600">{notice}</div>
               )}
               <PlantForm
                 initial={initial}


### PR DESCRIPTION
## Summary
- Return `{presets: null}` with 200 when species care presets are missing
- Show a gentle notice and fall back to base defaults when no presets available in Add Plant modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37efe64488324bd3e08784b1b02f2