### PR TITLE
Auto-generate care plan when presets are missing

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -34,6 +34,9 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json().catch(() => ({}));
+    if (body.planSource) {
+      console.log('Plan source:', body.planSource);
+    }
     const plant = await createPlant(userId!, body);
     return NextResponse.json(plant, { status: 201 });
   } catch (e: any) {

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -50,12 +50,14 @@ export default function PlantForm({
   onSubmit,
   onCancel,
   enableAiSubmit,
+  initialSuggest,
 }: {
   initial: PlantFormValues;
   submitLabel: string;
   onSubmit: (data: PlantFormSubmit, source?: 'ai' | 'manual') => Promise<void>;
   onCancel: () => void;
   enableAiSubmit?: boolean;
+  initialSuggest?: AiCareSuggestion | null;
 }) {
   const [state, setState] = useState<PlantFormValues>(initial);
   const [suggest, setSuggest] = useState<AiCareSuggestion | null>(null);
@@ -73,6 +75,30 @@ export default function PlantForm({
   useEffect(() => {
     setState(initial);
   }, [initial]);
+
+  useEffect(() => {
+    if (!initialSuggest) return;
+    setPrevManual({
+      waterEvery: initial.waterEvery,
+      waterAmount: initial.waterAmount,
+      fertEvery: initial.fertEvery,
+      fertFormula: initial.fertFormula,
+    });
+    setState((s) => ({
+      ...s,
+      waterEvery: initialSuggest.waterEvery
+        ? String(initialSuggest.waterEvery)
+        : s.waterEvery,
+      waterAmount: initialSuggest.waterAmount
+        ? String(initialSuggest.waterAmount)
+        : s.waterAmount,
+      fertEvery: initialSuggest.fertEvery
+        ? String(initialSuggest.fertEvery)
+        : s.fertEvery,
+      fertFormula: initialSuggest.fertFormula ?? s.fertFormula,
+    }));
+    setSuggest(initialSuggest);
+  }, [initialSuggest, initial]);
 
   useEffect(() => {
     async function fetchSuggest() {


### PR DESCRIPTION
## Summary
- call `/api/ai-care` after `loadDefaults` fails to find presets
- prefill PlantForm with AI suggestion and show it in Suggested plan
- log whether care plan came from presets or AI for debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3806d835883248c1a4f4a25a39596