### PR TITLE
Redirect /app to today and fix bottom navigation

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AppIndex() {
+  redirect("/app/today");
+}

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -1,5 +1,3 @@
-import type { Tab } from '@/components/BottomNav';
-
 "use client";
 
 import Link from "next/link";
@@ -485,7 +483,7 @@ export default function PlantDetailClient({ plant }: { plant: {
       </main>
 
       {/* Bottom nav */}
-      <BottomNav value="plants" onChange={(t: Tab) => router.push(`/app?tab=${t}`)} />
+      <BottomNav value="plants" />
       <EditPlantModal
         open={editOpen}
         onOpenChange={setEditOpen}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
       <div className="text-center space-y-4">
         <h1 className="text-2xl font-display font-semibold">Plant Dashboard</h1>
         <p>Open the app shell:</p>
-        <Link href="/app" className="underline">
+        <Link href="/app/today" className="underline">
           Go to App
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- Redirect /app to /app/today so initial app route loads
- Update home page link to target /app/today
- Remove leftover tab-based navigation in plant detail bottom nav

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a381a9b4d08324a0a796b36dfeea4f