### PR TITLE
Refactor plant creation modal into multi-step flow

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -3,9 +3,14 @@
 import React, { useEffect, useState } from 'react';
 import { Dialog } from '@headlessui/react';
 import { useRouter } from 'next/navigation';
-import PlantForm, {
+import {
+  BasicsFields,
+  EnvironmentFields,
+  CarePlanFields,
+  FormStyles,
   PlantFormSubmit,
   PlantFormValues,
+  plantValuesToSubmit,
 } from './PlantForm';
 import type { AiCareSuggestion } from '@/lib/aiCare';
 
@@ -24,12 +29,17 @@ export default function AddPlantModal({
 }) {
   const router = useRouter();
   const [initial, setInitial] = useState<PlantFormValues | null>(null);
+  const [values, setValues] = useState<PlantFormValues | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [initialSuggest, setInitialSuggest] = useState<AiCareSuggestion | null>(
     null,
   );
+  const [suggest, setSuggest] = useState<AiCareSuggestion | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [step, setStep] = useState<0 | 1 | 2>(0);
   const [planSource, setPlanSource] = useState<'preset' | 'ai' | null>(null);
 
   function close() {
@@ -42,6 +52,7 @@ export default function AddPlantModal({
       setLoading(true);
       setLoadError(null);
       setNotice(null);
+      setStep(0);
       const base: PlantFormValues = {
         name: prefillName || '',
         roomId: defaultRoomId,
@@ -66,10 +77,13 @@ export default function AddPlantModal({
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         const json = await r.json();
         if (json.presets) {
-          setInitial({ ...base, ...json.presets });
+          const init = { ...base, ...json.presets };
+          setInitial(init);
+          setValues(init);
           setPlanSource('preset');
         } else {
           setInitial(base);
+          setValues(base);
           setNotice('No presets found—generating AI suggestion');
           try {
             const ai = await fetch('/api/ai-care', {
@@ -87,6 +101,7 @@ export default function AddPlantModal({
             if (ai.ok) {
               const sug: AiCareSuggestion = await ai.json();
               setInitialSuggest(sug);
+              setSuggest(sug);
               setPlanSource('ai');
             } else {
               setNotice('No presets found and AI suggestion failed');
@@ -98,6 +113,7 @@ export default function AddPlantModal({
       } catch (e) {
         setLoadError('Failed to load species defaults.');
         setInitial(base);
+        setValues(base);
       } finally {
         setLoading(false);
       }
@@ -122,18 +138,80 @@ export default function AddPlantModal({
     router.push(`/app/plants/${created.id}?tab=photos`);
   }
 
+  async function submitCurrent(source: 'ai' | 'manual' = 'manual', override?: PlantFormValues) {
+    if (!values) return;
+    const current = override ?? values;
+    if (!current.name.trim()) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await handleSubmit(plantValuesToSubmit(current), source);
+    } catch (e: any) {
+      console.error('Error saving plant', e);
+      let message = 'Failed to save plant.';
+      try {
+        const status = e?.status ?? e?.response?.status;
+        let data: any = null;
+        if (e instanceof Response) {
+          data = await e.json().catch(() => null);
+        } else if (e?.response && typeof e.response.json === 'function') {
+          data = await e.response.json().catch(() => null);
+        } else if (e?.response?.data) {
+          data = e.response.data;
+        }
+        if (status === 401 || /401/.test(e?.message || '')) {
+          message = 'Please log in before adding a plant.';
+        } else if (data?.error) {
+          message = data.error;
+        } else if (data?.message) {
+          message = data.message;
+        } else if (data?.detail) {
+          message = data.detail;
+        } else if (typeof e?.message === 'string') {
+          message = e.message;
+        }
+      } catch (_) {
+        // ignore parse errors
+      }
+      setSaveError(message);
+      return;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSubmitAi() {
+    if (!suggest || !values) return;
+    const s: PlantFormValues = {
+      ...values,
+      waterEvery: String(suggest.waterEvery ?? Number(values.waterEvery)),
+      waterAmount: String(suggest.waterAmount ?? Number(values.waterAmount)),
+      fertEvery: String(suggest.fertEvery ?? Number(values.fertEvery)),
+      fertFormula: suggest.fertFormula ?? values.fertFormula,
+    };
+    await submitCurrent('ai', s);
+  }
+
+  function nextStep() {
+    setStep((s) => Math.min(s + 1, 2));
+  }
+
+  function prevStep() {
+    setStep((s) => Math.max(s - 1, 0));
+  }
+
   if (!open) return null;
 
   return (
     <Dialog open={open} onClose={close} className="relative z-50">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-end sm:items-center justify-center p-4">
-        <Dialog.Panel className="relative w-full sm:max-w-lg bg-white rounded-t-2xl sm:rounded-2xl shadow-xl max-h-[90vh] overflow-y-auto">
+      <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
+        <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-white rounded-none sm:rounded-2xl shadow-xl overflow-y-auto sm:max-h-[90vh]">
           <div className="p-5 border-b">
             <Dialog.Title className="text-lg font-display font-semibold">Add Plant</Dialog.Title>
           </div>
           {loading && <div className="p-5">Loading defaults…</div>}
-          {!loading && initial && (
+          {!loading && values && (
             <>
               {loadError && (
                 <div className="p-5 text-sm text-red-600">{loadError}</div>
@@ -141,14 +219,58 @@ export default function AddPlantModal({
               {notice && (
                 <div className="p-5 text-sm text-gray-600">{notice}</div>
               )}
-              <PlantForm
-                initial={initial}
-                submitLabel="Create Plant"
-                onSubmit={handleSubmit}
-                onCancel={close}
-                enableAiSubmit
-                initialSuggest={initialSuggest}
-              />
+              {step === 0 && <BasicsFields state={values} setState={setValues} />}
+              {step === 1 && <EnvironmentFields state={values} setState={setValues} />}
+              {step === 2 && (
+                <CarePlanFields
+                  state={values}
+                  setState={setValues}
+                  initialSuggest={initialSuggest}
+                  onSuggestChange={(s) => {
+                    setSuggest(s);
+                    if (s) setPlanSource('ai');
+                  }}
+                />
+              )}
+              {saveError && step === 2 && (
+                <div className="p-5 text-xs text-red-600">{saveError}</div>
+              )}
+              <div className="p-5 border-t flex gap-2 justify-end">
+                <button className="btn-secondary" onClick={close}>
+                  Cancel
+                </button>
+                {step > 0 && (
+                  <button className="btn-secondary" onClick={prevStep}>
+                    Back
+                  </button>
+                )}
+                {step < 2 && (
+                  <button className="btn" onClick={nextStep}>
+                    Next
+                  </button>
+                )}
+                {step === 2 && (
+                  <>
+                    {suggest && (
+                      <button
+                        className="btn"
+                        onClick={handleSubmitAi}
+                        disabled={saving || !values.name.trim()}
+                      >
+                        {saving ? 'Saving…' : 'Create with AI Plan'}
+                      </button>
+                    )}
+                    <button
+                      className="btn"
+                      onClick={() => submitCurrent('manual')}
+                      disabled={saving || !values.name.trim()}
+                    >
+                      {saving ? 'Saving…' : 'Create Plant'}
+                    </button>
+                  </>
+                )}
+              </div>
+              <FormStyles />
             </>
           )}
         </Dialog.Panel>

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 
 import type { AiCareSuggestion } from '@/lib/aiCare';
 
-import { fetchCareRules, CareSuggest } from '@/lib/careRules';
 
 import SpeciesAutosuggest from './SpeciesAutosuggest';
 
@@ -44,22 +43,164 @@ export type PlantFormSubmit = {
   rules: { type: 'water' | 'fertilize'; intervalDays: number; amountMl?: number; formula?: string }[];
 };
 
-export default function PlantForm({
-  initial,
-  submitLabel,
-  onSubmit,
-  onCancel,
-  enableAiSubmit,
-  initialSuggest,
-}: {
-  initial: PlantFormValues;
-  submitLabel: string;
-  onSubmit: (data: PlantFormSubmit, source?: 'ai' | 'manual') => Promise<void>;
-  onCancel: () => void;
-  enableAiSubmit?: boolean;
+export function plantValuesToSubmit(s: PlantFormValues): PlantFormSubmit {
+  return {
+    name: s.name.trim(),
+    roomId: s.roomId,
+    species: s.species || undefined,
+    potSize: s.pot,
+    potMaterial: s.potMaterial,
+    lightLevel: s.light,
+    indoor: s.indoor === 'Indoor',
+    soilType: s.soil || undefined,
+    drainage: s.drainage,
+    lat: Number(s.lat),
+    lon: Number(s.lon),
+    rules: [
+      {
+        type: 'water',
+        intervalDays: Number(s.waterEvery || 7),
+        amountMl: Number(s.waterAmount || 500),
+      },
+      {
+        type: 'fertilize',
+        intervalDays: Number(s.fertEvery || 30),
+        formula: s.fertFormula || undefined,
+      },
+    ],
+  };
+}
+
+type SectionProps = {
+  state: PlantFormValues;
+  setState: React.Dispatch<React.SetStateAction<PlantFormValues>>;
+};
+
+export function BasicsFields({ state, setState }: SectionProps) {
+  return (
+    <div className="p-5 space-y-4">
+      <Field label="Name">
+        <SpeciesAutosuggest
+          value={state.name}
+          onChange={(v) => setState({ ...state, name: v })}
+          onSelect={(s) => setState({ ...state, name: s.name, species: s.species })}
+        />
+      </Field>
+
+      <Field label="Room">
+        <RoomSelector
+          value={state.roomId}
+          onChange={(id) => setState({ ...state, roomId: id })}
+        />
+        <p className="hint">Stored locally in Settings → Defaults.</p>
+      </Field>
+
+      <div className="grid grid-cols-3 gap-3">
+        <Field label="Pot size">
+          <select
+            className="input"
+            value={state.pot}
+            onChange={(e) => setState({ ...state, pot: e.target.value })}
+          >
+            <option>4 in</option>
+            <option>6 in</option>
+            <option>8 in</option>
+          </select>
+        </Field>
+        <Field label="Pot material">
+          <select
+            className="input"
+            value={state.potMaterial}
+            onChange={(e) => setState({ ...state, potMaterial: e.target.value })}
+          >
+            <option>Plastic</option>
+            <option>Terracotta</option>
+            <option>Ceramic</option>
+          </select>
+        </Field>
+        <Field label="Light">
+          <select
+            className="input"
+            value={state.light}
+            onChange={(e) => setState({ ...state, light: e.target.value })}
+          >
+            <option>Low</option>
+            <option>Medium</option>
+            <option>Bright</option>
+          </select>
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+export function EnvironmentFields({ state, setState }: SectionProps) {
+  return (
+    <div className="p-5 space-y-4">
+      <Field label="Environment">
+        <div className="grid grid-cols-2 gap-3">
+          <select
+            className="input"
+            value={state.indoor}
+            onChange={(e) =>
+              setState({ ...state, indoor: e.target.value as 'Indoor' | 'Outdoor' })
+            }
+          >
+            <option>Indoor</option>
+            <option>Outdoor</option>
+          </select>
+          <select
+            className="input"
+            value={state.drainage}
+            onChange={(e) =>
+              setState({ ...state, drainage: e.target.value as 'poor' | 'ok' | 'great' })
+            }
+          >
+            <option value="poor">Poor drainage</option>
+            <option value="ok">OK drainage</option>
+            <option value="great">Great drainage</option>
+          </select>
+        </div>
+        <input
+          className="input mt-2"
+          value={state.soil}
+          onChange={(e) => setState({ ...state, soil: e.target.value })}
+          placeholder="Soil type (e.g., Aroid mix)"
+        />
+      </Field>
+
+      <Field label="Location (for weather)">
+        <div className="grid grid-cols-2 gap-3">
+          <input
+            className="input"
+            value={state.lat}
+            onChange={(e) => setState({ ...state, lat: e.target.value })}
+            placeholder="Latitude"
+          />
+          <input
+            className="input"
+            value={state.lon}
+            onChange={(e) => setState({ ...state, lon: e.target.value })}
+            placeholder="Longitude"
+          />
+        </div>
+        <p className="hint">Used to tailor intervals based on local conditions.</p>
+      </Field>
+    </div>
+  );
+}
+
+type CarePlanProps = SectionProps & {
   initialSuggest?: AiCareSuggestion | null;
-}) {
-  const [state, setState] = useState<PlantFormValues>(initial);
+  onSuggestChange?: (s: AiCareSuggestion | null) => void;
+};
+
+export function CarePlanFields({
+  state,
+  setState,
+  initialSuggest,
+  onSuggestChange,
+}: CarePlanProps) {
   const [suggest, setSuggest] = useState<AiCareSuggestion | null>(null);
   const [prevManual, setPrevManual] = useState<{
     waterEvery: string;
@@ -69,20 +210,14 @@ export default function PlantForm({
   } | null>(null);
   const [loadingSuggest, setLoadingSuggest] = useState(false);
   const [suggestError, setSuggestError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setState(initial);
-  }, [initial]);
 
   useEffect(() => {
     if (!initialSuggest) return;
     setPrevManual({
-      waterEvery: initial.waterEvery,
-      waterAmount: initial.waterAmount,
-      fertEvery: initial.fertEvery,
-      fertFormula: initial.fertFormula,
+      waterEvery: state.waterEvery,
+      waterAmount: state.waterAmount,
+      fertEvery: state.fertEvery,
+      fertFormula: state.fertFormula,
     });
     setState((s) => ({
       ...s,
@@ -98,7 +233,7 @@ export default function PlantForm({
       fertFormula: initialSuggest.fertFormula ?? s.fertFormula,
     }));
     setSuggest(initialSuggest);
-  }, [initialSuggest, initial]);
+  }, [initialSuggest, setState]);
 
   useEffect(() => {
     async function fetchSuggest() {
@@ -141,7 +276,11 @@ export default function PlantForm({
       }
     }
     fetchSuggest();
-  }, [state.species, state.pot, state.potMaterial]);
+  }, [state.species, state.pot, state.potMaterial, state.lat, state.lon, setState]);
+
+  useEffect(() => {
+    onSuggestChange?.(suggest);
+  }, [suggest, onSuggestChange]);
 
   function acceptSuggest() {
     setSuggest(null);
@@ -156,32 +295,119 @@ export default function PlantForm({
     setPrevManual(null);
   }
 
-  function toSubmit(s: PlantFormValues): PlantFormSubmit {
-    return {
-      name: s.name.trim(),
-      roomId: s.roomId,
-      species: s.species || undefined,
-      potSize: s.pot,
-      potMaterial: s.potMaterial,
-      lightLevel: s.light,
-      indoor: s.indoor === 'Indoor',
-      soilType: s.soil || undefined,
-      drainage: s.drainage,
-      lat: Number(s.lat),
-      lon: Number(s.lon),
-      rules: [
-        {
-          type: 'water',
-          intervalDays: Number(s.waterEvery || 7),
-          amountMl: Number(s.waterAmount || 500),
-        },
-        {
-          type: 'fertilize',
-          intervalDays: Number(s.fertEvery || 30),
-          formula: s.fertFormula || undefined,
-        },
-      ],
-    };
+  return (
+    <div className="p-5 space-y-4">
+      <div className="rounded-xl border p-3 bg-neutral-50">
+        <div className="text-sm font-medium mb-2">Suggested plan</div>
+        {loadingSuggest && (
+          <div className="text-xs text-neutral-600">Getting suggestions…</div>
+        )}
+        {suggestError && (
+          <div className="text-xs text-red-600 mb-2">{suggestError}</div>
+        )}
+        {!suggest && !loadingSuggest && (
+          <div className="text-xs text-neutral-600">
+            Select species and pot info to get AI recommendations.
+          </div>
+        )}
+        {suggest && !loadingSuggest && (
+          <div className="grid gap-2 text-sm">
+            <div className="grid grid-cols-2 gap-2">
+              <div className="rounded-lg border bg-white p-2">
+                <div className="text-xs text-neutral-500">Water</div>
+                <div className="font-medium">
+                  every {suggest.waterEvery} d · {suggest.waterAmount} ml
+                </div>
+              </div>
+              <div className="rounded-lg border bg-white p-2">
+                <div className="text-xs text-neutral-500">Fertilize</div>
+                <div className="font-medium">every {suggest.fertEvery} d</div>
+                {suggest.fertFormula && (
+                  <div className="text-xs text-neutral-500">{suggest.fertFormula}</div>
+                )}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button className="btn" onClick={acceptSuggest}>Use suggestions</button>
+              <button className="btn-secondary" onClick={overrideSuggest}>
+                Override manually
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Water every (days)">
+          <input
+            className="input"
+            type="number"
+            min={1}
+            value={state.waterEvery}
+            onChange={(e) => setState({ ...state, waterEvery: e.target.value })}
+          />
+        </Field>
+        <Field label="Water amount (ml)">
+          <input
+            className="input"
+            type="number"
+            min={50}
+            step={10}
+            value={state.waterAmount}
+            onChange={(e) => setState({ ...state, waterAmount: e.target.value })}
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Fertilize every (days)">
+          <input
+            className="input"
+            type="number"
+            min={7}
+            value={state.fertEvery}
+            onChange={(e) => setState({ ...state, fertEvery: e.target.value })}
+          />
+        </Field>
+        <Field label="Formula">
+          <input
+            className="input"
+            value={state.fertFormula}
+            onChange={(e) => setState({ ...state, fertFormula: e.target.value })}
+            placeholder="e.g., 10-10-10 @ 1/2 strength"
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+export default function PlantForm({
+  initial,
+  submitLabel,
+  onSubmit,
+  onCancel,
+  enableAiSubmit,
+  initialSuggest,
+}: {
+  initial: PlantFormValues;
+  submitLabel: string;
+  onSubmit: (data: PlantFormSubmit, source?: 'ai' | 'manual') => Promise<void>;
+  onCancel: () => void;
+  enableAiSubmit?: boolean;
+  initialSuggest?: AiCareSuggestion | null;
+}) {
+  const [state, setState] = useState<PlantFormValues>(initial);
+  const [suggest, setSuggest] = useState<AiCareSuggestion | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setState(initial);
+  }, [initial]);
+
+  function toSubmit() {
+    return plantValuesToSubmit(state);
   }
 
   async function handleSubmit(source: 'ai' | 'manual' = 'manual', override?: PlantFormValues) {
@@ -190,7 +416,7 @@ export default function PlantForm({
     setSaving(true);
     setSaveError(null);
     try {
-      await onSubmit(toSubmit(current), source);
+      await onSubmit(plantValuesToSubmit(current), source);
     } catch (e: any) {
       console.error('Error saving plant', e);
       let message = 'Failed to save plant.';
@@ -239,189 +465,15 @@ export default function PlantForm({
 
   return (
     <>
-      <div className="p-5 space-y-4">
-        <Field label="Name">
-          <SpeciesAutosuggest
-            value={state.name}
-            onChange={(v) => setState({ ...state, name: v })}
-            onSelect={(s) => setState({ ...state, name: s.name, species: s.species })}
-          />
-        </Field>
-
-        <Field label="Room">
-          <RoomSelector
-            value={state.roomId}
-            onChange={(id) => setState({ ...state, roomId: id })}
-          />
-          <p className="hint">Stored locally in Settings → Defaults.</p>
-        </Field>
-
-        <div className="grid grid-cols-3 gap-3">
-          <Field label="Pot size">
-            <select
-              className="input"
-              value={state.pot}
-              onChange={(e) => setState({ ...state, pot: e.target.value })}
-            >
-              <option>4 in</option>
-              <option>6 in</option>
-              <option>8 in</option>
-            </select>
-          </Field>
-          <Field label="Pot material">
-            <select
-              className="input"
-              value={state.potMaterial}
-              onChange={(e) => setState({ ...state, potMaterial: e.target.value })}
-            >
-              <option>Plastic</option>
-              <option>Terracotta</option>
-              <option>Ceramic</option>
-            </select>
-          </Field>
-          <Field label="Light">
-            <select
-              className="input"
-              value={state.light}
-              onChange={(e) => setState({ ...state, light: e.target.value })}
-            >
-              <option>Low</option>
-              <option>Medium</option>
-              <option>Bright</option>
-            </select>
-          </Field>
-        </div>
-
-        <Field label="Environment">
-          <div className="grid grid-cols-2 gap-3">
-            <select
-              className="input"
-              value={state.indoor}
-              onChange={(e) => setState({ ...state, indoor: e.target.value as 'Indoor' | 'Outdoor' })}
-            >
-              <option>Indoor</option>
-              <option>Outdoor</option>
-            </select>
-            <select
-              className="input"
-              value={state.drainage}
-              onChange={(e) => setState({ ...state, drainage: e.target.value as 'poor' | 'ok' | 'great' })}
-            >
-              <option value="poor">Poor drainage</option>
-              <option value="ok">OK drainage</option>
-              <option value="great">Great drainage</option>
-            </select>
-          </div>
-          <input
-            className="input mt-2"
-            value={state.soil}
-            onChange={(e) => setState({ ...state, soil: e.target.value })}
-            placeholder="Soil type (e.g., Aroid mix)"
-          />
-        </Field>
-
-        <Field label="Location (for weather)">
-          <div className="grid grid-cols-2 gap-3">
-            <input
-              className="input"
-              value={state.lat}
-              onChange={(e) => setState({ ...state, lat: e.target.value })}
-              placeholder="Latitude"
-            />
-            <input
-              className="input"
-              value={state.lon}
-              onChange={(e) => setState({ ...state, lon: e.target.value })}
-              placeholder="Longitude"
-            />
-          </div>
-          <p className="hint">Used to tailor intervals based on local conditions.</p>
-        </Field>
-
-        <div className="rounded-xl border p-3 bg-neutral-50">
-          <div className="text-sm font-medium mb-2">Suggested plan</div>
-          {loadingSuggest && (
-            <div className="text-xs text-neutral-600">Getting suggestions…</div>
-          )}
-          {suggestError && (
-            <div className="text-xs text-red-600 mb-2">{suggestError}</div>
-          )}
-          {!suggest && !loadingSuggest && (
-            <div className="text-xs text-neutral-600">
-              Select species and pot info to get AI recommendations.
-            </div>
-          )}
-          {suggest && !loadingSuggest && (
-            <div className="grid gap-2 text-sm">
-              <div className="grid grid-cols-2 gap-2">
-                <div className="rounded-lg border bg-white p-2">
-                  <div className="text-xs text-neutral-500">Water</div>
-                  <div className="font-medium">
-                    every {suggest.waterEvery} d · {suggest.waterAmount} ml
-                  </div>
-                </div>
-                <div className="rounded-lg border bg-white p-2">
-                  <div className="text-xs text-neutral-500">Fertilize</div>
-                  <div className="font-medium">every {suggest.fertEvery} d</div>
-                  {suggest.fertFormula && (
-                    <div className="text-xs text-neutral-500">{suggest.fertFormula}</div>
-                  )}
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button className="btn" onClick={acceptSuggest}>Use suggestions</button>
-                <button className="btn-secondary" onClick={overrideSuggest}>
-                  Override manually
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Water every (days)">
-            <input
-              className="input"
-              type="number"
-              min={1}
-              value={state.waterEvery}
-              onChange={(e) => setState({ ...state, waterEvery: e.target.value })}
-            />
-          </Field>
-          <Field label="Water amount (ml)">
-            <input
-              className="input"
-              type="number"
-              min={50}
-              step={10}
-              value={state.waterAmount}
-              onChange={(e) => setState({ ...state, waterAmount: e.target.value })}
-            />
-          </Field>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Fertilize every (days)">
-            <input
-              className="input"
-              type="number"
-              min={7}
-              value={state.fertEvery}
-              onChange={(e) => setState({ ...state, fertEvery: e.target.value })}
-            />
-          </Field>
-          <Field label="Formula">
-            <input
-              className="input"
-              value={state.fertFormula}
-              onChange={(e) => setState({ ...state, fertFormula: e.target.value })}
-              placeholder="e.g., 10-10-10 @ 1/2 strength"
-            />
-          </Field>
-        </div>
-
-        {saveError && <div className="text-xs text-red-600">{saveError}</div>}
-      </div>
+      <BasicsFields state={state} setState={setState} />
+      <EnvironmentFields state={state} setState={setState} />
+      <CarePlanFields
+        state={state}
+        setState={setState}
+        initialSuggest={initialSuggest}
+        onSuggestChange={setSuggest}
+      />
+      {saveError && <div className="p-5 text-xs text-red-600">{saveError}</div>}
       <div className="p-5 border-t flex gap-2 justify-end">
         <button className="btn-secondary" onClick={onCancel}>
           Cancel
@@ -435,13 +487,19 @@ export default function PlantForm({
           {saving ? 'Saving…' : submitLabel}
         </button>
       </div>
-      <style jsx>{`
-        .input { @apply w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-neutral-300; }
-        .btn { @apply rounded-lg bg-neutral-900 text-white text-sm px-3 py-2 disabled:opacity-70; }
-        .btn-secondary { @apply rounded-lg border text-sm px-3 py-2 bg-white; }
-        .hint { @apply text-xs text-neutral-500 mt-1; }
-      `}</style>
+      <FormStyles />
     </>
+  );
+}
+
+export function FormStyles() {
+  return (
+    <style jsx>{`
+      .input { @apply w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-neutral-300; }
+      .btn { @apply rounded-lg bg-neutral-900 text-white text-sm px-3 py-2 disabled:opacity-70; }
+      .btn-secondary { @apply rounded-lg border text-sm px-3 py-2 bg-white; }
+      .hint { @apply text-xs text-neutral-500 mt-1; }
+    `}</style>
   );
 }
 


### PR DESCRIPTION
## Summary
- add step-based flow to AddPlantModal with Basics, Environment, and Care Plan sections
- expose PlantForm step field components and conversion helper
- style dialog panel as full-screen sheet on mobile, card on desktop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a388d3a3a08324b0fca0b304db0039