### PR TITLE
Add inline validation to plant form fields

### DIFF
--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -13,10 +13,12 @@ export default function SpeciesAutosuggest({
   value,
   onChange,
   onSelect,
+  onBlur,
 }: {
   value: string;
   onChange: (v: string) => void;
   onSelect: (s: Suggestion) => void;
+  onBlur?: () => void;
 }) {
   const [query, setQuery] = useState(value);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
@@ -93,7 +95,10 @@ export default function SpeciesAutosuggest({
         value={query}
         onChange={handleChange}
         onFocus={() => { if (suggestions.length) setOpen(true); }}
-        onBlur={() => setTimeout(() => setOpen(false), 100)}
+        onBlur={() => {
+          onBlur?.();
+          setTimeout(() => setOpen(false), 100);
+        }}
         placeholder="e.g., Monstera"
       />
       {open && suggestions.length > 0 && (


### PR DESCRIPTION
## Summary
- add real-time validation for required name and numeric lat/long
- show inline success/error messaging beside inputs
- propagate blur events through SpeciesAutosuggest for validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb71fb2083248910bfd9ef2ed794