### PR TITLE
Track care plan source metadata for plants

### DIFF
--- a/app/api/plants/route.test.ts
+++ b/app/api/plants/route.test.ts
@@ -47,4 +47,33 @@ describe('GET/POST /api/plants', () => {
     expect(createPlant).toHaveBeenCalledWith('user-1', { name: 'New Plant' });
     expect(createRouteHandlerClient).toHaveBeenCalled();
   });
+
+  it('creates plant with care plan details', async () => {
+    const newPlant = { id: 'p_new', name: 'New Plant' };
+    (createPlant as jest.Mock).mockResolvedValue(newPlant);
+
+    const mockSupabase = { auth: { getUser: jest.fn() } };
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue(mockSupabase);
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+
+    const req = new Request('http://localhost/api/plants', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'New Plant',
+        carePlanSource: 'ai',
+        aiModel: 'gpt',
+        aiVersion: '1',
+      }),
+    });
+
+    const res = await POST(req as any);
+    expect(res.status).toBe(201);
+    await res.json();
+    expect(createPlant).toHaveBeenCalledWith('user-1', {
+      name: 'New Plant',
+      carePlanSource: 'ai',
+      aiModel: 'gpt',
+      aiVersion: '1',
+    });
+  });
 });

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -34,9 +34,6 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json().catch(() => ({}));
-    if (body.planSource) {
-      console.log('Plan source:', body.planSource);
-    }
     const plant = await createPlant(userId!, body);
     return NextResponse.json(plant, { status: 201 });
   } catch (e: any) {

--- a/app/api/species-care/route.ts
+++ b/app/api/species-care/route.ts
@@ -5,11 +5,16 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const species = searchParams.get('species') || '';
+    const key = species.trim().toLowerCase();
     const defaults = await getCareDefaults(species);
     if (!defaults) {
       return NextResponse.json({ presets: null });
     }
-    return NextResponse.json({ presets: defaults, updated: new Date().toISOString() });
+    return NextResponse.json({
+      presets: defaults,
+      presetId: key,
+      updated: new Date().toISOString(),
+    });
   } catch (e: any) {
     console.error('GET /api/species-care failed:', e);
     return NextResponse.json({ error: 'server' }, { status: 500 });

--- a/lib/aiCare.ts
+++ b/lib/aiCare.ts
@@ -14,6 +14,8 @@ export type AiCareSuggestion = {
   waterAmount: number;
   fertEvery: number;
   fertFormula?: string;
+  model?: string;
+  version?: string;
 };
 
 export async function suggestCare({
@@ -60,6 +62,8 @@ export async function suggestCare({
     waterAmount: data.waterAmount,
     fertEvery: data.fertEvery,
     fertFormula: data.fertFormula,
+    model: completion.model,
+    version: completion.system_fingerprint,
   };
 }
 

--- a/lib/prisma/plants.ts
+++ b/lib/prisma/plants.ts
@@ -11,6 +11,10 @@ type PlantData = {
   soilType?: string | null;
   lat?: number | null;
   lon?: number | null;
+  carePlanSource?: string | null;
+  presetId?: string | null;
+  aiModel?: string | null;
+  aiVersion?: string | null;
 };
 
 export async function listPlants(): Promise<Plant[]> {
@@ -33,6 +37,10 @@ export async function createPlant(userId: string, data: PlantData): Promise<Plan
       soilType: data.soilType,
       latitude: data.lat ?? undefined,
       longitude: data.lon ?? undefined,
+      carePlanSource: data.carePlanSource ?? undefined,
+      presetId: data.presetId ?? undefined,
+      aiModel: data.aiModel ?? undefined,
+      aiVersion: data.aiVersion ?? undefined,
     },
   });
 }
@@ -47,11 +55,15 @@ export async function updatePlant(id: string, data: PlantData): Promise<Plant | 
         species: data.species,
         potSize: data.potSize,
         potMaterial: data.potMaterial,
-        soilType: data.soilType,
-        latitude: data.lat ?? undefined,
-        longitude: data.lon ?? undefined,
-      },
-    });
+      soilType: data.soilType,
+      latitude: data.lat ?? undefined,
+      longitude: data.lon ?? undefined,
+      carePlanSource: data.carePlanSource ?? undefined,
+      presetId: data.presetId ?? undefined,
+      aiModel: data.aiModel ?? undefined,
+      aiVersion: data.aiVersion ?? undefined,
+    },
+  });
   } catch (e: any) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
       return null;

--- a/prisma/migrations/20250819000000_care_plan_source/migration.sql
+++ b/prisma/migrations/20250819000000_care_plan_source/migration.sql
@@ -1,0 +1,5 @@
+-- Add care plan source fields
+ALTER TABLE "public"."Plant" ADD COLUMN "care_plan_source" TEXT;
+ALTER TABLE "public"."Plant" ADD COLUMN "preset_id" TEXT;
+ALTER TABLE "public"."Plant" ADD COLUMN "ai_model" TEXT;
+ALTER TABLE "public"."Plant" ADD COLUMN "ai_version" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,10 @@ model Plant {
   soilType    String?  @map("soil_type")
   latitude    Float?
   longitude   Float?
+  carePlanSource String? @map("care_plan_source")
+  presetId   String?  @map("preset_id")
+  aiModel    String?  @map("ai_model")
+  aiVersion  String?  @map("ai_version")
   createdAt   DateTime @default(now()) @map("created_at")
 
   tasks  Task[]

--- a/supabase/migrations/0003_care_plan_source.sql
+++ b/supabase/migrations/0003_care_plan_source.sql
@@ -1,0 +1,6 @@
+-- Supabase migration to add care plan source fields to plants
+alter table public.plants
+  add column care_plan_source text,
+  add column preset_id text,
+  add column ai_model text,
+  add column ai_version text;


### PR DESCRIPTION
## Summary
- Capture AI model/version or preset IDs in plant care plan metadata
- Send care plan details when creating plants and store them in the database
- Add database migrations for new care plan fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3bf6f55588324b9b6d745466ce032