### PR TITLE
docs: clarify db:seed usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 3. Prepare the database and start the app
    ```bash
    npm run db:migrate
-   npm run db:seed
    npm run dev
    # open http://localhost:3000/app
    ```
+   The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Migrations already create empty tables, so run this script only if you need to wipe existing data.
 
 ## Common Scripts
 | command | description |
@@ -30,7 +30,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 | `npm run dev` | start development server |
 | `npm run build` | create production build |
 | `npm run db:migrate` | run Prisma migrations |
-| `npm run db:seed` | seed database with sample data |
+| `npm run db:seed` | clear `task` and `plant` tables |
 
 ## Testing
 - Unit tests: `npm test`


### PR DESCRIPTION
## Summary
- document that `npm run db:seed` only clears `task` and `plant` tables
- adjust quick start to omit `db:seed` from setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c34964388324903d4d84bbd74ace