### PR TITLE
Add rooms table migration and Prisma model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,15 @@ model Plant {
   @@schema("public")
 }
 
+model Room {
+  id     String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId String @map("user_id") @db.Uuid
+  name   String
+
+  @@map("rooms")
+  @@schema("public")
+}
+
 model Task {
   id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId     String    @map("user_id") @db.Uuid

--- a/supabase/migrations/0004_rooms.sql
+++ b/supabase/migrations/0004_rooms.sql
@@ -1,0 +1,14 @@
+-- Supabase migration to create rooms table
+create table if not exists public.rooms (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null
+);
+
+alter table public.rooms enable row level security;
+
+create policy "Rooms are user specific" on public.rooms
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+grant usage on schema public to postgres, anon, authenticated, service_role;
+grant all on table public.rooms to postgres, anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- create `rooms` table with RLS policy and privileges for PostgREST
- add `Room` model to Prisma schema

## Testing
- `npx prisma db pull` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d530dfbc8324aa10cad52e821162