### PR TITLE
Use Prisma db:sync instead of migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,24 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
    - `SINGLE_USER_MODE` and `SINGLE_USER_ID` for skipping Supabase auth
 3. Sync Prisma schema and client
    ```bash
-   npx prisma db pull
-   npx prisma generate
+   npm run db:sync
    ```
-   These commands keep the Prisma schema and generated client up to date.
-4. Prepare the database and start the app
+   This pulls the latest schema from Supabase and regenerates the Prisma client.
+4. Start the app
    ```bash
-   npm run db:migrate
    npm run dev
    # open http://localhost:3000/app
    ```
-   The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Migrations already create empty tables, so run this script only if you need to wipe existing data.
+   The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Run it only if you need to wipe existing data.
 
 ## Common Scripts
 | command | description |
 |---|---|
 | `npm run dev` | start development server |
 | `npm run build` | create production build |
-| `npm run db:migrate` | run Prisma migrations |
+| `npm run db:sync` | sync schema from DB and generate Prisma client |
 | `npm run db:seed` | clear `task` and `plant` tables |
-| `npx prisma db pull` | sync schema from DB |
-| `npx prisma generate` | generate Prisma client |
+| `npm run db:studio` | open Prisma Studio |
 
 ## Testing
 - Unit tests: `npm test`

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "db:migrate": "prisma migrate dev",
+    "db:sync": "prisma db pull && prisma generate",
     "db:seed": "prisma db seed",
+    "db:studio": "prisma studio",
     "test": "jest"
   },
   "dependencies": {
@@ -36,8 +37,5 @@
     "tailwindcss": "^3.4.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.0"
-  },
-  "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   }
 }

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,3 @@
+export default {
+  schema: './prisma/schema.prisma',
+};


### PR DESCRIPTION
## Summary
- replace `db:migrate` with `db:sync` script and add `db:studio`
- remove deprecated `package.json#prisma` config in favor of `prisma.config.ts`
- update README to run `npm run db:sync` and document new scripts

## Testing
- `npm test`
- `npm run db:sync` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d6f0e0b08324a605d445c190a1ef