### PR TITLE
feat: add plant notes API

### DIFF
--- a/app/api/plants/[id]/notes/route.ts
+++ b/app/api/plants/[id]/notes/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await ctx.params;
+    const supabase = await createRouteHandlerClient();
+    const { data, error } = await supabase
+      .from('plant_notes')
+      .select('id, note, created_at')
+      .eq('plant_id', id)
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    const notes = (data ?? []).map(n => ({
+      id: n.id,
+      note: n.note,
+      createdAt: n.created_at,
+    }));
+    return NextResponse.json(notes);
+  } catch (e) {
+    console.error("GET /api/plants/[id]/notes failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await ctx.params;
+    const supabase = await createRouteHandlerClient();
+
+    const singleUser = process.env.SINGLE_USER_MODE === "true";
+    let userId: string | undefined;
+    if (singleUser) {
+      userId = process.env.SINGLE_USER_ID;
+      if (!userId) {
+        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
+        return NextResponse.json({ error: "server" }, { status: 500 });
+      }
+    } else {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (userError || !user) {
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      }
+      userId = user.id;
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const note = typeof body.note === "string" ? body.note.trim() : "";
+    if (!note) {
+      return NextResponse.json({ error: "note required" }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('plant_notes')
+      .insert({ user_id: userId, plant_id: id, note })
+      .select('id, note, created_at')
+      .single();
+    if (error) throw error;
+    return NextResponse.json({
+      id: data.id,
+      note: data.note,
+      createdAt: data.created_at,
+    }, { status: 201 });
+  } catch (e) {
+    console.error("POST /api/plants/[id]/notes failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}

--- a/lib/supabase.types.ts
+++ b/lib/supabase.types.ts
@@ -121,6 +121,40 @@ export interface Database {
           }
         ];
       };
+      plant_notes: {
+        Row: {
+          id: string;
+          user_id: string;
+          plant_id: string;
+          note: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          plant_id: string;
+          note: string;
+          created_at?: string | null;
+        };
+        Update: {
+          note?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "plant_notes_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "plant_notes_plant_id_fkey";
+            columns: ["plant_id"];
+            referencedRelation: "plants";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/supabase/migrations/0005_plant_notes.sql
+++ b/supabase/migrations/0005_plant_notes.sql
@@ -1,0 +1,13 @@
+-- Supabase migration to create plant_notes table
+create table if not exists public.plant_notes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  plant_id uuid not null references public.plants(id) on delete cascade,
+  note text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.plant_notes enable row level security;
+
+create policy "Plant notes are user specific" on public.plant_notes
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase migration and types for plant notes
- implement GET and POST routes for plant notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d941eea483248c7f75f6f1e0eaaf