### PR TITLE
feat: validate Supabase env vars

### DIFF
--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -3,15 +3,20 @@ import { createRouteHandlerClient } from "@/lib/supabase";
 
 export async function GET() {
   try {
-    const supabase = await createRouteHandlerClient();
     const singleUser = process.env.SINGLE_USER_MODE === "true";
+    if (
+      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      (singleUser && !process.env.SINGLE_USER_ID)
+    ) {
+      console.error("Missing Supabase environment variables");
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+
+    const supabase = await createRouteHandlerClient();
     let userId: string | undefined;
     if (singleUser) {
-      userId = process.env.SINGLE_USER_ID;
-      if (!userId) {
-        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
-        return NextResponse.json({ error: "server" }, { status: 500 });
-      }
+      userId = process.env.SINGLE_USER_ID!;
     } else {
       const {
         data: { user },
@@ -40,15 +45,20 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = await createRouteHandlerClient();
     const singleUser = process.env.SINGLE_USER_MODE === "true";
+    if (
+      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      (singleUser && !process.env.SINGLE_USER_ID)
+    ) {
+      console.error("Missing Supabase environment variables");
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+
+    const supabase = await createRouteHandlerClient();
     let userId: string | undefined;
     if (singleUser) {
-      userId = process.env.SINGLE_USER_ID;
-      if (!userId) {
-        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
-        return NextResponse.json({ error: "server" }, { status: 500 });
-      }
+      userId = process.env.SINGLE_USER_ID!;
     } else {
       const {
         data: { user },


### PR DESCRIPTION
## Summary
- check required Supabase env vars before instantiating client
- return `{ error: "misconfigured server" }` when missing
- test error cases for missing env vars and single user ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d94e430c8324bc9fa681f0575a22