### PR TITLE
Handle missing env vars in plants API

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -4,6 +4,14 @@ import { createRouteHandlerClient } from "@/lib/supabase";
 
 export async function GET() {
   try {
+    if (!process.env.DATABASE_URL) {
+      console.error("Missing DATABASE_URL environment variable");
+      return NextResponse.json(
+        { error: "misconfigured server" },
+        { status: 500 }
+      );
+    }
+
     const plants = await listPlants();
     return NextResponse.json(plants);
   } catch (e: any) {
@@ -14,15 +22,24 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = await createRouteHandlerClient();
     const singleUser = process.env.SINGLE_USER_MODE === "true";
+    if (
+      !process.env.DATABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      (singleUser && !process.env.SINGLE_USER_ID)
+    ) {
+      console.error("Missing Supabase or database environment variables");
+      return NextResponse.json(
+        { error: "misconfigured server" },
+        { status: 500 }
+      );
+    }
+
+    const supabase = await createRouteHandlerClient();
     let userId: string | undefined;
     if (singleUser) {
-      userId = process.env.SINGLE_USER_ID;
-      if (!userId) {
-        console.error("SINGLE_USER_MODE enabled but SINGLE_USER_ID not set");
-        return NextResponse.json({ error: "server" }, { status: 500 });
-      }
+      userId = process.env.SINGLE_USER_ID!;
     } else {
       const {
         data: { user },


### PR DESCRIPTION
## Summary
- validate required database and Supabase env vars in `/api/plants`
- add tests covering env var checks and single-user mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3dcf182688324ae42d32ad7b63575