### PR TITLE
Add user context to plant photo uploads

### DIFF
--- a/lib/supabase.types.ts
+++ b/lib/supabase.types.ts
@@ -155,6 +155,32 @@ export interface Database {
           }
         ];
       };
+      rooms: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          created_at?: string | null;
+        };
+        Update: {
+          name?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "rooms_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
     };
     Views: {
       [_ in never]: never;


### PR DESCRIPTION
## Summary
- retrieve authenticated user or single-user ID when uploading plant photos and store user_id in database
- extend Supabase types with rooms table definition

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: TS2322 etc in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e238bdd48324924764f66c48c1e9