### PR TITLE
Handle invalid task window env var

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -21,9 +21,19 @@ import {
   Filter as FilterIcon,
 } from "lucide-react";
 
-const DEFAULT_TASK_WINDOW_DAYS = Number(
-  process.env.NEXT_PUBLIC_TASK_WINDOW_DAYS ?? "7",
-);
+const DEFAULT_TASK_WINDOW_DAYS = (() => {
+  const parsed = parseInt(
+    process.env.NEXT_PUBLIC_TASK_WINDOW_DAYS ?? "7",
+    10,
+  );
+  if (Number.isNaN(parsed)) {
+    console.warn(
+      `Invalid NEXT_PUBLIC_TASK_WINDOW_DAYS value "${process.env.NEXT_PUBLIC_TASK_WINDOW_DAYS}", falling back to 7`,
+    );
+    return 7;
+  }
+  return parsed;
+})();
 const URGENT_WINDOW_DAYS = 2;
 
 function isSameDay(a: Date, b: Date) {


### PR DESCRIPTION
## Summary
- use `parseInt` to read `NEXT_PUBLIC_TASK_WINDOW_DAYS`
- default to 7 days and warn if the env var is invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e31dab10832482ae3b4c5a719b46