### PR TITLE
feat: validate Supabase env vars

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,9 @@
+export const NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+if (!NEXT_PUBLIC_SUPABASE_URL) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not defined');
+}
+
+export const NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+if (!NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined');
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,12 +1,16 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 import type { Database } from './supabase.types';
+import {
+  NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SUPABASE_URL,
+} from './env';
 
 // Factory for an unauthenticated client
 export function createSupabaseClient(): SupabaseClient<Database> {
   return createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY,
   );
 }
 
@@ -15,8 +19,8 @@ export async function createRouteHandlerClient(): Promise<SupabaseClient<Databas
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('sb-access-token')?.value;
   return createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       global: {
         headers: {


### PR DESCRIPTION
## Summary
- validate required Supabase env vars at startup
- use validated env vars in Supabase client helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e3285bec83248574dfc7fb752cd5