### PR TITLE
Load dotenv in Prisma config

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,3 +1,3 @@
-export default {
-  schema: './prisma/schema.prisma',
-};
+import 'dotenv/config';
+
+export default { schema: './prisma/schema.prisma' };


### PR DESCRIPTION
## Summary
- load .env automatically in Prisma config

## Testing
- `npm run db:sync` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e38161a4832488bcefd383784229