### PR TITLE
Handle API errors in AddPlantModal

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -175,7 +175,10 @@ export default function AddPlantModal({
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    if (!r.ok) {
+      // Throw the full response so callers can inspect status and body
+      throw r;
+    }
     const created = await r.json();
     onCreate(data.name);
     close();


### PR DESCRIPTION
## Summary
- throw response object when plant creation fails so callers can read status/body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ea2898f08324aa6aad7ad024a4a6