### PR TITLE
Improve Add Plant form labels and steppers

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -50,10 +50,16 @@ export default function AddPlantModal({
     potMaterial: string;
     light: string;
   } | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
 
   function close() {
     onOpenChange(false);
   }
+
+  const showToast = (m: string) => {
+    setToast(m);
+    setTimeout(() => setToast(null), 3000);
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -154,6 +160,17 @@ export default function AddPlantModal({
     }
     loadDefaults();
   }, [open, prefillName, defaultRoomId]);
+
+  function updateDefaults(field: 'pot' | 'potMaterial' | 'light', value: string) {
+    const next = { ...(defaults || { pot: '', potMaterial: '', light: '' }), [field]: value };
+    setDefaults(next);
+    try {
+      const stored = JSON.parse(localStorage.getItem('plantDefaults') || '{}');
+      stored[field] = value;
+      localStorage.setItem('plantDefaults', JSON.stringify(stored));
+    } catch {}
+    showToast('Defaults saved.');
+  }
 
   async function handleSubmit(
     data: PlantFormSubmit,
@@ -280,6 +297,7 @@ export default function AddPlantModal({
                   state={values}
                   setState={setValues}
                   defaults={defaults || undefined}
+                  saveDefault={updateDefaults}
                 />
               )}
               {step === 1 && <EnvironmentFields state={values} setState={setValues} />}
@@ -325,6 +343,11 @@ export default function AddPlantModal({
           )}
         </Dialog.Panel>
       </div>
+      {toast && (
+        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 bg-neutral-900 text-white text-sm px-4 py-2 rounded-full shadow-lg">
+          {toast}
+        </div>
+      )}
     </Dialog>
   );
 }

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -130,9 +130,11 @@ export function BasicsFields({
   setState,
   validation = emptyValidation,
   defaults,
+  saveDefault,
 }: SectionProps & {
   validation?: Validation;
   defaults?: { pot: string; potMaterial: string; light: string };
+  saveDefault?: (field: 'pot' | 'potMaterial' | 'light', value: string) => void;
 }) {
   const { errors, touched, validate, markTouched } = validation;
   return (
@@ -182,6 +184,15 @@ export function BasicsFields({
             value={state.pot}
             onChange={(v) => setState({ ...state, pot: v })}
           />
+          {defaults && defaults.pot !== state.pot && (
+            <button
+              type="button"
+              className="text-xs underline"
+              onClick={() => saveDefault?.('pot', state.pot)}
+            >
+              Save as new default
+            </button>
+          )}
           <p className="hint">Larger pots stay moist longer.</p>
         </Field>
         <Field label="Pot material" defaulted={defaults?.potMaterial === state.potMaterial}>
@@ -190,6 +201,15 @@ export function BasicsFields({
             value={state.potMaterial}
             onChange={(v) => setState({ ...state, potMaterial: v })}
           />
+          {defaults && defaults.potMaterial !== state.potMaterial && (
+            <button
+              type="button"
+              className="text-xs underline"
+              onClick={() => saveDefault?.('potMaterial', state.potMaterial)}
+            >
+              Save as new default
+            </button>
+          )}
           {state.pot && (
             <p className="hint">
               {state.pot}{' '}
@@ -207,6 +227,15 @@ export function BasicsFields({
             value={state.light}
             onChange={(v) => setState({ ...state, light: v })}
           />
+          {defaults && defaults.light !== state.light && (
+            <button
+              type="button"
+              className="text-xs underline"
+              onClick={() => saveDefault?.('light', state.light)}
+            >
+              Save as new default
+            </button>
+          )}
         </Field>
       </div>
     </div>
@@ -282,15 +311,18 @@ export function EnvironmentFields({
             <option value="great">Great drainage</option>
           </select>
         </div>
-        {showMore && (
+      </Field>
+
+      {showMore && (
+        <Field label="Soil type">
           <input
-            className="input mt-2"
+            className="input"
             value={state.soil}
             onChange={(e) => setState({ ...state, soil: e.target.value })}
-            placeholder="Soil type (e.g., Aroid mix)"
+            placeholder="e.g., cactus mix"
           />
-        )}
-      </Field>
+        </Field>
+      )}
 
       <Field label="Location (for weather)">
         <div className="grid gap-2">
@@ -298,12 +330,15 @@ export function EnvironmentFields({
             Use current location
           </button>
           <div className="flex gap-2">
-            <input
-              className="input flex-1"
-              value={address}
-              onChange={(e) => setAddress(e.target.value)}
-              placeholder="Search address"
-            />
+            <div className="flex-1 grid gap-1">
+              <label className="text-xs text-neutral-700">Search address</label>
+              <input
+                className="input"
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                placeholder="e.g., 123 Main St"
+              />
+            </div>
             <button type="button" className="btn-secondary" onClick={lookupAddress}>
               Search
             </button>
@@ -311,6 +346,7 @@ export function EnvironmentFields({
           {showMore && (
             <div className="grid grid-cols-2 gap-3">
               <div className="grid gap-1">
+                <label className="text-xs text-neutral-700">Latitude</label>
                 <input
                   className="input"
                   value={state.lat ?? ''}
@@ -324,7 +360,7 @@ export function EnvironmentFields({
                     markTouched('lat');
                     validate('lat', state.lat);
                   }}
-                  placeholder="Latitude"
+                  placeholder="e.g., 40.7128"
                 />
                 {touched.lat && (
                   errors.lat ? (
@@ -335,6 +371,7 @@ export function EnvironmentFields({
                 )}
               </div>
               <div className="grid gap-1">
+                <label className="text-xs text-neutral-700">Longitude</label>
                 <input
                   className="input"
                   value={state.lon ?? ''}
@@ -348,7 +385,7 @@ export function EnvironmentFields({
                     markTouched('lon');
                     validate('lon', state.lon);
                   }}
-                  placeholder="Longitude"
+                  placeholder="e.g., -74.0060"
                 />
                 {touched.lon && (
                   errors.lon ? (
@@ -555,15 +592,17 @@ export function CarePlanFields({
             onChange={(v) => setState({ ...state, waterEvery: v })}
             min={1}
           />
+          <p className="hint">Use arrows or type a number.</p>
           {nextWater && <p className="hint">Next watering: {fmtDate(nextWater)}</p>}
         </Field>
         <Field label="Water amount (ml)">
           <Stepper
             value={state.waterAmount}
             onChange={(v) => setState({ ...state, waterAmount: v })}
-            min={50}
+            min={10}
             step={10}
           />
+          <p className="hint">Use arrows or type a number.</p>
         </Field>
       </div>
 
@@ -573,8 +612,9 @@ export function CarePlanFields({
           <Stepper
             value={state.fertEvery}
             onChange={(v) => setState({ ...state, fertEvery: v })}
-            min={7}
+            min={1}
           />
+          <p className="hint">Use arrows or type a number.</p>
           {nextFertilize && (
             <p className="hint">Next fertilizing: {fmtDate(nextFertilize)}</p>
           )}
@@ -754,8 +794,8 @@ function Field({
       <label className="text-sm font-medium text-neutral-700 flex items-center gap-2">
         {label}
         {defaulted && (
-          <span className="text-[10px] uppercase text-neutral-500 border px-1 rounded">
-            Default
+          <span className="text-[10px] text-neutral-500 border px-1 rounded">
+            Using your default
           </span>
         )}
       </label>

--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -99,7 +99,7 @@ export default function SpeciesAutosuggest({
           onBlur?.();
           setTimeout(() => setOpen(false), 100);
         }}
-        placeholder="e.g., Monstera"
+        placeholder="e.g., Monstera deliciosa"
       />
       {open && suggestions.length > 0 && (
         <ul

--- a/components/Stepper.test.ts
+++ b/components/Stepper.test.ts
@@ -1,0 +1,13 @@
+import { clampValue } from './Stepper';
+
+describe('clampValue', () => {
+  it('enforces minimum for days', () => {
+    expect(clampValue(0, 1, 1)).toBe(1);
+  });
+  it('clamps ml to minimum', () => {
+    expect(clampValue(5, 10, 10)).toBe(10);
+  });
+  it('rounds to step', () => {
+    expect(clampValue(25, 10, 10)).toBe(30);
+  });
+});

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -1,5 +1,14 @@
 'use client';
 
+export function clampValue(n: number, min: number, step: number) {
+  if (Number.isNaN(n)) return min;
+  n = Math.max(min, n);
+  if (step > 1) {
+    n = Math.round(n / step) * step;
+  }
+  return n;
+}
+
 export default function Stepper({
   value,
   onChange,
@@ -12,14 +21,9 @@ export default function Stepper({
   step?: number;
 }) {
   const num = Number(value) || 0;
-  const dec = () => {
-    const next = num - step;
-    onChange(String(next < min ? min : next));
-  };
-  const inc = () => {
-    const next = num + step;
-    onChange(String(next));
-  };
+  const set = (v: number) => onChange(String(clampValue(v, min, step)));
+  const dec = () => set(num - step);
+  const inc = () => set(num + step);
   return (
     <div className="flex items-center gap-2">
       <button
@@ -30,9 +34,27 @@ export default function Stepper({
         -
       </button>
       <input
+        type="number"
         className="input w-16 text-center"
         value={value}
-        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ''))}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          if (e.target.value === '') {
+            onChange('');
+          } else {
+            set(v);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            set(num + 1);
+          } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            set(num - 1);
+          }
+        }}
+        min={min}
       />
       <button
         type="button"


### PR DESCRIPTION
## Summary
- ensure Add Plant inputs have persistent labels and example placeholders
- allow steppers to accept typed values and keyboard arrows with value clamping
- show default-setting controls with toast feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ebcc78348324a5b6b804b6071d9d