### PR TITLE
feat: improve add plant inputs and defaults

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -73,6 +73,28 @@ export default function AddPlantModal({
     potMaterial: string;
     light: string;
   } | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  function saveDefault(
+    field: 'pot' | 'potMaterial' | 'light',
+    value: string,
+  ) {
+    setDefaults((d) => ({ ...(d || {}), [field]: value }));
+    try {
+      const stored = JSON.parse(localStorage.getItem('plantDefaults') || '{}');
+      localStorage.setItem(
+        'plantDefaults',
+        JSON.stringify({ ...stored, [field]: value }),
+      );
+    } catch {}
+    setToast('Defaults saved.');
+  }
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   function close() {
     onOpenChange(false);
@@ -289,93 +311,101 @@ export default function AddPlantModal({
   if (!open) return null;
 
   return (
-    <Dialog
-      open={open}
-      onClose={close}
-      className="relative z-50"
-      initialFocus={firstFieldRef}
-      aria-labelledby={titleId}
-    >
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
-        <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-white rounded-none sm:rounded-2xl shadow-xl overflow-y-auto sm:max-h-[90vh]">
-          <div className="p-5 border-b">
-            <Dialog.Title
-              id={titleId}
-              className="text-lg font-display font-semibold"
-            >
-              Add Plant
-            </Dialog.Title>
-          </div>
-          {loading && (
-            <div className="p-5 space-y-4 animate-pulse">
-              <div className="h-6 bg-neutral-200 rounded" />
-              <div className="h-6 bg-neutral-200 rounded" />
-              <div className="h-6 bg-neutral-200 rounded" />
+    <>
+      <Dialog
+        open={open}
+        onClose={close}
+        className="relative z-50"
+        initialFocus={firstFieldRef}
+        aria-labelledby={titleId}
+      >
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+        <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
+          <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-white rounded-none sm:rounded-2xl shadow-xl overflow-y-auto sm:max-h-[90vh]">
+            <div className="p-5 border-b">
+              <Dialog.Title
+                id={titleId}
+                className="text-lg font-display font-semibold"
+              >
+                Add Plant
+              </Dialog.Title>
             </div>
-          )}
-          {!loading && values && (
-            <>
-              {notice && (
-                <div className="p-5 text-sm text-gray-600">{notice}</div>
-              )}
-              {step === 0 && (
-                <BasicsFields
-                  state={values}
-                  setState={setValues}
-                  defaults={defaults || undefined}
-                  nameInputRef={firstFieldRef}
-                />
-              )}
-              {step === 1 && <EnvironmentFields state={values} setState={setValues} />}
-              {step === 2 && (
-                <CarePlanFields
-                  state={values}
-                  setState={setValues}
-                  initialSuggest={initialSuggest}
-                  onPlanModeChange={setPlanSource}
-                />
-              )}
-              <div className="p-5 border-t flex gap-2 justify-end items-center">
-                {saveError && step === 2 && (
-                  <div className="text-xs text-red-600 mr-auto">{saveError}</div>
-                )}
-                <button className="btn-secondary" onClick={close}>
-                  Cancel
-                </button>
-                {step > 0 && (
-                  <button className="btn-secondary" onClick={prevStep}>
-                    Back
-                  </button>
-                )}
-                {step < 2 && (
-                  <button className="btn" onClick={nextStep}>
-                    Next
-                  </button>
-                )}
-                {step === 2 && (
-                  <button
-                    className="btn"
-                    onClick={() =>
-                      submitCurrent(planSource?.type === 'ai' ? 'ai' : 'manual')
-                    }
-                    disabled={saving || !values.name.trim()}
-                  >
-                    {saving
-                      ? 'Saving…'
-                      : saveError
-                      ? 'Retry'
-                      : planSource && planSource.type !== 'manual'
-                      ? 'Create with Suggested Plan'
-                      : 'Create Plant (Manual)'}
-                  </button>
-                )}
+            {loading && (
+              <div className="p-5 space-y-4 animate-pulse">
+                <div className="h-6 bg-neutral-200 rounded" />
+                <div className="h-6 bg-neutral-200 rounded" />
+                <div className="h-6 bg-neutral-200 rounded" />
               </div>
-              <FormStyles />
-            </>
-          )}
-        </Dialog.Panel>
-      </div>
-    </Dialog>
+            )}
+            {!loading && values && (
+              <>
+                {notice && (
+                  <div className="p-5 text-sm text-gray-600">{notice}</div>
+                )}
+                {step === 0 && (
+                  <BasicsFields
+                    state={values}
+                    setState={setValues}
+                    defaults={defaults || undefined}
+                    nameInputRef={firstFieldRef}
+                    onSaveDefault={saveDefault}
+                  />
+                )}
+                {step === 1 && <EnvironmentFields state={values} setState={setValues} />}
+                {step === 2 && (
+                  <CarePlanFields
+                    state={values}
+                    setState={setValues}
+                    initialSuggest={initialSuggest}
+                    onPlanModeChange={setPlanSource}
+                  />
+                )}
+                <div className="p-5 border-t flex gap-2 justify-end items-center">
+                  {saveError && step === 2 && (
+                    <div className="text-xs text-red-600 mr-auto">{saveError}</div>
+                  )}
+                  <button className="btn-secondary" onClick={close}>
+                    Cancel
+                  </button>
+                  {step > 0 && (
+                    <button className="btn-secondary" onClick={prevStep}>
+                      Back
+                    </button>
+                  )}
+                  {step < 2 && (
+                    <button className="btn" onClick={nextStep}>
+                      Next
+                    </button>
+                  )}
+                  {step === 2 && (
+                    <button
+                      className="btn"
+                      onClick={() =>
+                        submitCurrent(planSource?.type === 'ai' ? 'ai' : 'manual')
+                      }
+                      disabled={saving || !values.name.trim()}
+                    >
+                      {saving
+                        ? 'Saving…'
+                        : saveError
+                        ? 'Retry'
+                        : planSource && planSource.type !== 'manual'
+                        ? 'Create with Suggested Plan'
+                        : 'Create Plant (Manual)'}
+                    </button>
+                  )}
+                </div>
+                <FormStyles />
+              </>
+            )}
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+      {toast && (
+        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 bg-neutral-900 text-white text-sm px-4 py-2 rounded-full shadow-lg">
+          {toast}
+        </div>
+      )}
+    </>
   );
 }

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -140,10 +140,12 @@ export function BasicsFields({
   validation = emptyValidation,
   defaults,
   nameInputRef,
+  onSaveDefault,
 }: SectionProps & {
   validation?: Validation;
   defaults?: { pot: string; potMaterial: string; light: string };
   nameInputRef?: React.RefObject<HTMLInputElement>;
+  onSaveDefault?: (field: 'pot' | 'potMaterial' | 'light', value: string) => void;
 }) {
   const { errors, touched, validate, markTouched } = validation;
   return (
@@ -205,14 +207,36 @@ export function BasicsFields({
             value={state.pot}
             onChange={(v) => setState({ ...state, pot: v })}
           />
+          {defaults && defaults.pot !== state.pot && onSaveDefault && (
+            <button
+              type="button"
+              className="text-xs underline text-left"
+              onClick={() => onSaveDefault('pot', state.pot)}
+            >
+              Save as new default
+            </button>
+          )}
           <p className="hint">Larger pots stay moist longer.</p>
         </Field>
-        <Field label="Pot material" defaulted={defaults?.potMaterial === state.potMaterial}>
+        <Field
+          label="Pot material"
+          defaulted={defaults?.potMaterial === state.potMaterial}
+        >
           <ChipSelect
             options={["Plastic", "Terracotta", "Ceramic"]}
             value={state.potMaterial}
             onChange={(v) => setState({ ...state, potMaterial: v })}
           />
+          {defaults && defaults.potMaterial !== state.potMaterial &&
+            onSaveDefault && (
+              <button
+                type="button"
+                className="text-xs underline text-left"
+                onClick={() => onSaveDefault('potMaterial', state.potMaterial)}
+              >
+                Save as new default
+              </button>
+            )}
           {state.pot && (
             <p className="hint">
               {state.pot}{' '}
@@ -230,6 +254,15 @@ export function BasicsFields({
             value={state.light}
             onChange={(v) => setState({ ...state, light: v })}
           />
+          {defaults && defaults.light !== state.light && onSaveDefault && (
+            <button
+              type="button"
+              className="text-xs underline text-left"
+              onClick={() => onSaveDefault('light', state.light)}
+            >
+              Save as new default
+            </button>
+          )}
         </Field>
       </div>
     </div>
@@ -314,15 +347,17 @@ export function EnvironmentFields({
             <option value="great">Great drainage</option>
           </select>
         </div>
-        {showMore && (
+      </Field>
+      {showMore && (
+        <Field label="Soil type">
           <input
-            className="input mt-2"
+            className="input"
             value={state.soil}
             onChange={(e) => setState({ ...state, soil: e.target.value })}
-            placeholder="Soil type (e.g., Aroid mix)"
+            placeholder="e.g., cactus mix"
           />
-        )}
-      </Field>
+        </Field>
+      )}
 
       <Field label="Location (for weather)">
         <div className="grid gap-2">
@@ -607,6 +642,7 @@ export function CarePlanFields({
               <span className="text-xs text-green-600">Looks good!</span>
             )
           )}
+          <p className="hint">Use arrows or type a number.</p>
           {nextWater && <p className="hint">Next watering: {fmtDate(nextWater)}</p>}
         </Field>
         <Field label="Water amount (ml)">
@@ -627,6 +663,7 @@ export function CarePlanFields({
               <span className="text-xs text-green-600">Looks good!</span>
             )
           )}
+          <p className="hint">Use arrows or type a number.</p>
         </Field>
       </div>
 
@@ -649,6 +686,7 @@ export function CarePlanFields({
               <span className="text-xs text-green-600">Looks good!</span>
             )
           )}
+          <p className="hint">Use arrows or type a number.</p>
           {nextFertilize && (
             <p className="hint">Next fertilizing: {fmtDate(nextFertilize)}</p>
           )}
@@ -849,8 +887,8 @@ function Field({
       <label className="text-sm font-medium text-neutral-700 flex items-center gap-2">
         {label}
         {defaulted && (
-          <span className="text-[10px] uppercase text-neutral-500 border px-1 rounded">
-            Default
+          <span className="text-[10px] text-neutral-500 border px-1 rounded">
+            Using your default
           </span>
         )}
       </label>

--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -116,7 +116,7 @@ export default function SpeciesAutosuggest({
           onBlur?.();
           setTimeout(() => setOpen(false), 100);
         }}
-        placeholder="e.g., Monstera"
+        placeholder="e.g., Monstera deliciosa"
       />
       {open && (
         <ul

--- a/components/Stepper.test.tsx
+++ b/components/Stepper.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Stepper from './Stepper';
+
+describe('Stepper', () => {
+  it('clamps to the minimum on blur', () => {
+    function Wrapper() {
+      const [v, setV] = useState('1');
+      return <Stepper value={v} onChange={setV} min={1} />;
+    }
+    const { getByRole } = render(<Wrapper />);
+    const input = getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('1');
+  });
+
+  it('rounds to step multiples on blur', () => {
+    function Wrapper() {
+      const [v, setV] = useState('100');
+      return <Stepper value={v} onChange={setV} min={10} step={10} />;
+    }
+    const { getByRole } = render(<Wrapper />);
+    const input = getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '123' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('120');
+  });
+});
+

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -12,13 +12,31 @@ export default function Stepper({
   step?: number;
 }) {
   const num = Number(value) || 0;
+  const clamp = (n: number) => {
+    let res = n;
+    if (res < min) res = min;
+    if (step > 1) {
+      res = Math.round(res / step) * step;
+    }
+    return res;
+  };
   const dec = () => {
-    const next = num - step;
-    onChange(String(next < min ? min : next));
+    onChange(String(clamp(num - step)));
   };
   const inc = () => {
-    const next = num + step;
-    onChange(String(next));
+    onChange(String(clamp(num + step)));
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      onChange(String(clamp(num + 1)));
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      onChange(String(clamp(num - 1)));
+    }
+  };
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    onChange(String(clamp(Number(e.target.value) || 0)));
   };
   return (
     <div className="flex items-center gap-2">
@@ -30,9 +48,13 @@ export default function Stepper({
         -
       </button>
       <input
+        type="number"
         className="input w-16 text-center"
         value={value}
-        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ''))}
+        min={min}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
       />
       <button
         type="button"


### PR DESCRIPTION
## Summary
- add visible labels and example placeholders in Add Plant form
- allow keyboard-friendly steppers with value clamping
- surface saved defaults with pill and save-as-default link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ee8127188324872b1703fec0004c