### PR TITLE
Enhance AI plant care with richer environmental context

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -122,6 +122,7 @@ export default function AddPlantModal({
         indoor: 'Indoor',
         drainage: 'ok',
         soil: stored.soil || 'Well-draining mix',
+        humidity: stored.humidity || '50',
         lat: '',
         lon: '',
         waterEvery: '7',
@@ -163,6 +164,11 @@ export default function AddPlantModal({
               species: base.species,
               potSize: base.pot,
               potMaterial: base.potMaterial,
+              light: base.light,
+              indoor: base.indoor === 'Indoor',
+              drainage: base.drainage,
+              soil: base.soil,
+              humidity: Number(base.humidity),
             };
             if (base.lat && base.lon) {
               aiBody.lat = Number(base.lat);
@@ -262,6 +268,7 @@ export default function AddPlantModal({
             potMaterial: current.potMaterial,
             light: current.light,
             soil: current.soil,
+            humidity: current.humidity,
             fertFormula: current.fertFormula,
           }),
         );

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -23,6 +23,7 @@ export type PlantFormValues = {
   indoor: 'Indoor' | 'Outdoor';
   drainage: 'poor' | 'ok' | 'great';
   soil: string;
+  humidity: string;
   lat?: string;
   lon?: string;
   waterEvery: string;
@@ -349,14 +350,24 @@ export function EnvironmentFields({
         </div>
       </Field>
       {showMore && (
-        <Field label="Soil type">
-          <input
-            className="input"
-            value={state.soil}
-            onChange={(e) => setState({ ...state, soil: e.target.value })}
-            placeholder="e.g., cactus mix"
-          />
-        </Field>
+        <>
+          <Field label="Soil type">
+            <input
+              className="input"
+              value={state.soil}
+              onChange={(e) => setState({ ...state, soil: e.target.value })}
+              placeholder="e.g., cactus mix"
+            />
+          </Field>
+          <Field label="Humidity (%)">
+            <Stepper
+              value={state.humidity}
+              onChange={(v) => setState({ ...state, humidity: v })}
+              min={0}
+              step={5}
+            />
+          </Field>
+        </>
       )}
 
       <Field label="Location (for weather)">
@@ -522,6 +533,11 @@ export function CarePlanFields({
           species: state.species,
           potSize: state.pot,
           potMaterial: state.potMaterial,
+          light: state.light,
+          indoor: state.indoor === 'Indoor',
+          drainage: state.drainage,
+          soil: state.soil,
+          humidity: Number(state.humidity),
         };
         if (state.lat && state.lon) {
           body.lat = Number(state.lat);
@@ -556,7 +572,20 @@ export function CarePlanFields({
       }
     }
     if (showSuggest) fetchSuggest();
-  }, [state.species, state.pot, state.potMaterial, state.lat, state.lon, setState, showSuggest]);
+  }, [
+    state.species,
+    state.pot,
+    state.potMaterial,
+    state.light,
+    state.indoor,
+    state.drainage,
+    state.soil,
+    state.humidity,
+    state.lat,
+    state.lon,
+    setState,
+    showSuggest,
+  ]);
 
   useEffect(() => {
     onSuggestChange?.(suggest);


### PR DESCRIPTION
## Summary
- expand `suggestCare` to include light, humidity, soil, drainage, indoor/outdoor status, local evapotranspiration and season, using `gpt-4o` for responses
- capture humidity in the Add Plant flow and forward environmental details to the AI suggestion service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ef8319e48324abc5b00f4fed1798