### PR TITLE
feat: improve touch targets and theme tokens

### DIFF
--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -3,10 +3,11 @@
 import { useState } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { coreColors } from "@/lib/design-tokens"
+import { lightTokens, darkTokens } from "@/lib/design-tokens"
 
 export default function StyleGuidePreviewPage() {
   const [previewMode, setPreviewMode] = useState<"light" | "dark">("light")
+  const tokens = previewMode === "light" ? lightTokens : darkTokens
 
   return (
     <div
@@ -32,11 +33,11 @@ export default function StyleGuidePreviewPage() {
         <CardContent className="p-6">
           <h2 className="text-xl font-display font-semibold mb-4">Core Tokens</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <ColorSwatch name="Primary" hex={coreColors.primary} />
-            <ColorSwatch name="Secondary" hex={coreColors.secondary} />
-            <ColorSwatch name="Background" hex={coreColors.background} text="black" />
-            <ColorSwatch name="Foreground" hex={coreColors.foreground} />
-            <ColorSwatch name="Muted" hex={coreColors.muted} />
+            <ColorSwatch name="Primary" hex={tokens.primary} />
+            <ColorSwatch name="Secondary" hex={tokens.secondary} />
+            <ColorSwatch name="Background" hex={tokens.background} text="black" />
+            <ColorSwatch name="Foreground" hex={tokens.foreground} />
+            <ColorSwatch name="Muted" hex={tokens.muted} />
           </div>
         </CardContent>
       </Card>

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -120,10 +120,10 @@ function ChipSelect({
         <button
           key={opt}
           type="button"
-          className={`px-3 py-1 rounded-full border text-sm ${
+          className={`min-w-11 min-h-11 px-3 py-2 rounded-full border text-sm flex items-center justify-center ${
             value === opt
               ? 'bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900'
-              : 'bg-white dark:bg-neutral-800'
+              : 'bg-white text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100'
           }`}
           onClick={() => onChange(opt)}
         >
@@ -862,8 +862,8 @@ export function FormStyles() {
   return (
     <style jsx>{`
       .input { @apply w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-neutral-300; }
-      .btn { @apply rounded-lg bg-neutral-900 text-white text-sm px-3 py-2 disabled:opacity-70; }
-      .btn-secondary { @apply rounded-lg border text-sm px-3 py-2 bg-white; }
+      .btn { @apply inline-flex items-center justify-center rounded-lg bg-neutral-900 text-white text-sm px-4 py-3 min-h-11 min-w-11 disabled:opacity-70 dark:bg-neutral-100 dark:text-neutral-900; }
+      .btn-secondary { @apply inline-flex items-center justify-center rounded-lg border border-neutral-300 text-sm px-4 py-3 bg-white text-neutral-900 min-h-11 min-w-11 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700; }
       .hint { @apply text-xs text-neutral-500 mt-1; }
     `}</style>
   );

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -42,14 +42,15 @@ export default function Stepper({
     <div className="flex items-center gap-2">
       <button
         type="button"
-        className="px-2 py-1 border rounded"
+        className="w-11 h-11 flex items-center justify-center border rounded bg-white text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100"
         onClick={dec}
+        aria-label="Decrease value"
       >
         -
       </button>
       <input
         type="number"
-        className="input w-16 text-center"
+        className="input w-16 text-center h-11"
         value={value}
         min={min}
         onChange={(e) => onChange(e.target.value)}
@@ -58,8 +59,9 @@ export default function Stepper({
       />
       <button
         type="button"
-        className="px-2 py-1 border rounded"
+        className="w-11 h-11 flex items-center justify-center border rounded bg-white text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100"
         onClick={inc}
+        aria-label="Increase value"
       >
         +
       </button>

--- a/lib/__snapshots__/design-tokens.test.ts.snap
+++ b/lib/__snapshots__/design-tokens.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`design tokens matches dark token snapshot 1`] = `
+{
+  "background": "#111827",
+  "foreground": "#F9F9F9",
+  "muted": "#9CA3AF",
+  "primary": "#508C7E",
+  "secondary": "#1E483D",
+}
+`;
+
+exports[`design tokens matches light token snapshot 1`] = `
+{
+  "background": "#F9F9F9",
+  "foreground": "#111827",
+  "muted": "#9CA3AF",
+  "primary": "#508C7E",
+  "secondary": "#D3EDE6",
+}
+`;

--- a/lib/design-tokens.test.ts
+++ b/lib/design-tokens.test.ts
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+import { lightTokens, darkTokens } from './design-tokens';
+
+describe('design tokens', () => {
+  it('matches light token snapshot', () => {
+    expect(lightTokens).toMatchSnapshot();
+  });
+  it('matches dark token snapshot', () => {
+    expect(darkTokens).toMatchSnapshot();
+  });
+});

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,8 +1,17 @@
-export const coreColors = {
+export const lightTokens = {
   primary: "#508C7E",
   secondary: "#D3EDE6",
   background: "#F9F9F9",
   foreground: "#111827",
   muted: "#9CA3AF",
-}
+};
 
+export const darkTokens = {
+  primary: "#508C7E",
+  secondary: "#1E483D",
+  background: "#111827",
+  foreground: "#F9F9F9",
+  muted: "#9CA3AF",
+};
+
+export const coreColors = lightTokens;


### PR DESCRIPTION
## Summary
- ensure chips, steppers, and modal buttons meet 44x44 touch target with accessible contrast
- add light/dark theme tokens and update style guide
- snapshot tests for design tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f1f7093083249046c02230437e34