### PR TITLE
Improve logging for plant save errors

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -302,7 +302,14 @@ export default function AddPlantModal({
       } catch (_) {
         // ignore parse errors
       }
-      console.error('Error saving plant', { status, data, error: e });
+      const context: Record<string, unknown> = {};
+      if (status !== undefined) context.status = status;
+      if (data !== null) context.data = data;
+      if (Object.keys(context).length > 0) {
+        console.error('Error saving plant', e, context);
+      } else {
+        console.error('Error saving plant', e);
+      }
       setSaveError(message);
       return;
     } finally {


### PR DESCRIPTION
## Summary
- clarify plant-save error logs by separating error and context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f9c145308324921ef740400a6dd9