### PR TITLE
Use existing photos endpoint for uploads

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -217,19 +217,13 @@ export default function PlantDetailClient({ plant }: { plant: {
     const formData = new FormData();
     formData.append("file", newPhotoFile);
     try {
-      const upload = await fetch(`/api/upload`, {
+      const upload = await fetch(`/api/plants/${id}/photos`, {
         method: "POST",
         body: formData,
       });
       if (!upload.ok) throw new Error();
-      const data = await upload.json().catch(() => ({}));
-      const src: string | undefined = data.src || data.url;
+      const { src } = await upload.json();
       if (!src) throw new Error();
-      await fetch(`/api/plants/${id}/photos`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ src }),
-      });
       setPhotos((p) => [...p, src]);
       setNewPhotoFile(null);
     } catch {}


### PR DESCRIPTION
## Summary
- Send plant photo uploads directly to `/api/plants/[id]/photos`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f665f82c83249e899e4c04e22edb