### PR TITLE
Fix rooms API 500 due to missing Supabase envs

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,9 +1,0 @@
-export const NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-if (!NEXT_PUBLIC_SUPABASE_URL) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not defined');
-}
-
-export const NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-if (!NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined');
-}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,36 +1,36 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { cookies } from 'next/headers';
-import type { Database } from './supabase.types';
-import {
-  NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  NEXT_PUBLIC_SUPABASE_URL,
-} from './env';
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { cookies } from "next/headers";
+import type { Database } from "./supabase.types";
+
+function getSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error("Missing Supabase environment variables");
+  }
+  return { url, anonKey };
+}
 
 // Factory for an unauthenticated client
 export function createSupabaseClient(): SupabaseClient<Database> {
-  return createClient<Database>(
-    NEXT_PUBLIC_SUPABASE_URL,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  );
+  const { url, anonKey } = getSupabaseEnv();
+  return createClient<Database>(url, anonKey);
 }
 
 // Authenticated client helper for Route Handlers
 export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('sb-access-token')?.value;
-  return createClient<Database>(
-    NEXT_PUBLIC_SUPABASE_URL,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      global: {
-        headers: {
-          Authorization: accessToken ? `Bearer ${accessToken}` : '',
-        },
-      },
-      auth: {
-        persistSession: false,
-        autoRefreshToken: false,
+  const { url, anonKey } = getSupabaseEnv();
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get("sb-access-token")?.value;
+  return createClient<Database>(url, anonKey, {
+    global: {
+      headers: {
+        Authorization: accessToken ? `Bearer ${accessToken}` : "",
       },
     },
-  );
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- read Supabase environment variables at runtime so API routes don't crash on import
- remove eager env loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3fbb15fe48324b40bdaad6f0128ee