### PR TITLE
fix supabase auth for Next 15 async cookies

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -20,7 +20,8 @@ export function createSupabaseClient(): SupabaseClient<Database> {
 // Authenticated client helper for Route Handlers
 export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
   const { url, anonKey } = getSupabaseEnv();
-  const cookieStore = cookies();
+  // `cookies()` is now asynchronous in Next 15 and must be awaited
+  const cookieStore = await cookies();
   const accessToken = cookieStore.get("sb-access-token")?.value;
   return createClient<Database>(url, anonKey, {
     global: {


### PR DESCRIPTION
## Summary
- await `cookies()` when building Supabase client so API routes work under Next 15

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe319544832489d8d727242b7750