### PR TITLE
Remove AI-generated plan notice

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -189,7 +189,7 @@ export default function AddPlantModal({
                 aiModel: sug.model,
                 aiVersion: sug.version,
               });
-              setNotice('AI-generated plan…');
+              setNotice(null);
             } else {
               setNotice('No suggestions available.');
               setPlanSource({ type: 'manual' });


### PR DESCRIPTION
## Summary
- Stop displaying "AI-generated plan" notice when an AI care suggestion is provided, keeping the Add Plant form cleaner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe62679c8324aaeb0b8ae460afe7