### PR TITLE
chore: configure Inter font with Tailwind variables

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
+import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/ThemeProvider";
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
   title: "Kay Maria",
@@ -20,7 +22,7 @@ export default function RootLayout({
 }) {
   return (
     // Avoid hydration mismatches when extensions add attributes to <html>
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={inter.variable}>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,8 +10,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        display: ["Cabinet Grotesk", "ui-sans-serif", "system-ui", "sans-serif"],
-        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "ui-sans-serif", "system-ui", "sans-serif"],
+        sans: ["var(--font-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
       },
       colors: {
         background: "hsl(var(--background))",


### PR DESCRIPTION
## Summary
- import and configure Inter font with next/font
- apply Inter CSS variable to document
- reference font CSS variables in Tailwind config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a401b4a880832490633cb989600af5