### PR TITLE
chore(prisma): ignore supabase system tables

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,4 +77,5 @@ model User {
 
   @@map("users")
   @@schema("auth")
+  @@ignore
 }


### PR DESCRIPTION
## Summary
- ignore Supabase auth.users table in Prisma schema

## Testing
- `npx prisma db pull` *(fails: Environment variable not found: DATABASE_URL)*
- `npx prisma generate`
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40189259c8324aa7199c46bcce443