### PR TITLE
Use UI icon button for theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Sun, Moon } from "lucide-react";
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
@@ -9,13 +11,15 @@ export default function ThemeToggle() {
   useEffect(() => setMounted(true), []);
 
   if (!mounted) return null;
-
+  const isDark = theme === "dark";
   return (
-    <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="border rounded px-3 py-2 text-sm"
+    <Button
+      variant="secondary"
+      size="icon"
+      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
     >
-      {theme === "dark" ? "Light Mode" : "Dark Mode"}
-    </button>
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- replace text theme toggle with icon `Button`
- add Sun and Moon icons for light and dark themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a401b868e8832497ed7548581c95e2