### PR TITLE
refactor: use Card and Button in SettingsView

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import TaskRow from "@/components/TaskRow";
 import ThemeToggle from "@/components/ThemeToggle";
 import { TaskDTO } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { motion } from "framer-motion";
 import {
   Select,
@@ -617,27 +619,31 @@ export function SettingsView() {
       </header>
       <main className="flex-1 px-4 pb-28">
         <section className="mt-4 grid gap-3">
-          <div className="rounded-xl border bg-white shadow-sm p-4 dark:bg-neutral-800 dark:border-neutral-700">
-            <div className="text-base font-medium">Export / Import</div>
-            <div className="text-sm text-neutral-600 dark:text-neutral-300">
-              Backup JSON / CSV; restore from file
-            </div>
-            <div className="mt-2 flex gap-2">
-              <button className="border rounded px-3 py-2 text-sm">
+          <Card>
+            <CardHeader className="pb-2">
+              <div className="text-base font-medium">Export / Import</div>
+              <div className="text-sm text-neutral-600 dark:text-neutral-300">
+                Backup JSON / CSV; restore from file
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0 flex gap-2">
+              <Button variant="secondary" size="sm">
                 Export JSON
-              </button>
-              <button className="border rounded px-3 py-2 text-sm">
+              </Button>
+              <Button variant="secondary" size="sm">
                 Export CSV
-              </button>
-              <button className="bg-neutral-900 text-white rounded px-3 py-2 text-sm dark:bg-neutral-100 dark:text-neutral-900">
+              </Button>
+              <Button variant="default" size="sm">
                 Import
-              </button>
-            </div>
-          </div>
-          <div className="rounded-xl border bg-white shadow-sm p-4 flex items-center justify-between dark:bg-neutral-800 dark:border-neutral-700">
-            <div className="text-base font-medium">Theme</div>
-            <ThemeToggle />
-          </div>
+              </Button>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex items-center justify-between">
+              <div className="text-base font-medium">Theme</div>
+              <ThemeToggle />
+            </CardContent>
+          </Card>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- refactor Settings view to use Card layout components
- replace raw buttons with Button component variants

## Testing
- `npm test`
- `npm run build` *(fails: Property 'userId' does not exist on type 'GetUserIdResult')*


------
https://chatgpt.com/codex/tasks/task_e_68a401bc86a08324b7c79dc4c1261b8a