### PR TITLE
feat: add insights route for plant and task counts

### DIFF
--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase";
+import { getUserId } from "@/lib/getUserId";
+
+export async function GET() {
+  const supabase = await createRouteHandlerClient();
+  const { userId, error: userIdError } = await getUserId(supabase);
+  if (userIdError === "unauthorized")
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (userIdError)
+    return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+
+  const [plantRes, taskRes] = await Promise.all([
+    supabase
+      .from("plants")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+    supabase
+      .from("tasks")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+  ]);
+
+  if (plantRes.error) {
+    console.error("GET /api/insights plant count failed:", plantRes.error);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+  if (taskRes.error) {
+    console.error("GET /api/insights task count failed:", taskRes.error);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    plantCount: plantRes.count ?? 0,
+    taskCount: taskRes.count ?? 0,
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/insights` endpoint that returns counts of plants and tasks for the authenticated user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4023da18c8324b589a89b72288365