### PR TITLE
feat: add basic supabase auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 DATABASE_URL="postgresql://user:password@host:5432/dbname"
 NEXT_PUBLIC_TASK_WINDOW_DAYS=7
 OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 2. Create `.env` from `.env.example` and supply the required values:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
    - `NEXT_PUBLIC_BASE_URL`
    - `DATABASE_URL`
    - `OPENAI_API_KEY` *(optional)*
@@ -27,6 +28,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
    # open http://localhost:3000/app
    ```
    The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Run it only if you need to wipe existing data.
+   Log in at `http://localhost:3000/login` with a Supabase email/password account. Use the Settings page to sign out.
 
 ## Common Scripts
 | command | description |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ See [roadmap v1](./docs/roadmaps/roadmap-v1.md) for previous phases. Additional 
 This document outlines upcoming work for the Kay Maria plant care app.
 
 - [ ] Multi-device sync
-  - [ ] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
+  - [x] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
   - [ ] Real-time data sync across devices
 - [ ] Regression tests
   - [ ] End-to-end test suite

--- a/app/api/plants/[id]/notes/route.ts
+++ b/app/api/plants/[id]/notes/route.ts
@@ -28,13 +28,14 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   try {
     const { id } = await ctx.params;
     const supabase = await createRouteHandlerClient();
-    const { userId, error: userIdError } = await getUserId(supabase);
-    if (userIdError === "unauthorized") {
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    }
-    if (userIdError) {
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized") {
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      }
       return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
     }
+    const { userId } = userRes;
 
     const body = await req.json().catch(() => ({}));
     const note = typeof body.note === "string" ? body.note.trim() : "";

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -41,18 +41,17 @@ export async function POST(req: NextRequest) {
     }
 
     const supabase = await createRouteHandlerClient();
-    const { userId, error } = await getUserId(supabase);
-    if (error === "unauthorized")
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    if (error)
-      return NextResponse.json(
-        { error: "misconfigured server" },
-        { status: 500 }
-      );
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized")
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+    const { userId } = userRes;
 
     const body = await req.json().catch(() => ({}));
     const { lastWateredAt, lastFertilizedAt, ...rest } = body;
-    const plant = await createPlant(userId!, {
+    const plant = await createPlant(userId, {
       ...rest,
       ...(lastWateredAt ? { lastWateredAt } : {}),
       ...(lastFertilizedAt ? { lastFertilizedAt } : {}),

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -13,14 +13,13 @@ export async function GET() {
     }
 
     const supabase = await createRouteHandlerClient();
-    const { userId, error: userIdError } = await getUserId(supabase);
-    if (userIdError === "unauthorized")
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    if (userIdError)
-      return NextResponse.json(
-        { error: "misconfigured server" },
-        { status: 500 }
-      );
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized")
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+    const { userId } = userRes;
 
     const { data, error: dbError } = await supabase
       .from("rooms")
@@ -49,14 +48,13 @@ export async function POST(req: NextRequest) {
     }
 
     const supabase = await createRouteHandlerClient();
-    const { userId, error: userIdError } = await getUserId(supabase);
-    if (userIdError === "unauthorized")
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    if (userIdError)
-      return NextResponse.json(
-        { error: "misconfigured server" },
-        { status: 500 }
-      );
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized")
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+    const { userId } = userRes;
 
     const body = await req.json().catch(() => ({}));
     const name = String(body.name || "").trim();

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase";
+import { createSupabaseAdminClient } from "@/lib/supabaseAdmin";
+import { getUserId } from "@/lib/getUserId";
+
+export async function POST() {
+  try {
+    const supabase = await createRouteHandlerClient();
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized")
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+    const { userId } = userRes;
+
+    const admin = createSupabaseAdminClient();
+    void admin; // placeholder for future sync logic
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    console.error("POST /api/sync failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -65,8 +65,8 @@ export async function PATCH(req: NextRequest, ctx: any) {
             "id, plant_id, type, due_at, plant:plants(id, name, room_id)",
           )
           .eq("user_id", userId)
-          .eq("plant_id", plantId)
-          .eq("type", type)
+          .eq("plant_id", plantId as string)
+          .eq("type", type as string)
           .single();
 
     if (fetchError || !existing)
@@ -87,7 +87,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
       }
       const rec = {
         id: data.id,
-        plantId: data.plant?.id ?? data.plant_id,
+        plantId: data.plant?.id ?? (data as any).plant_id,
         plantName: data.plant?.name ?? "",
         roomId: data.plant?.room_id ?? "",
         type: data.type,

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -4,11 +4,13 @@ import { getUserId } from "@/lib/getUserId";
 
 export async function GET(req: NextRequest) {
   const supabase = await createRouteHandlerClient();
-  const { userId, error: userIdError } = await getUserId(supabase);
-  if (userIdError === "unauthorized")
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-  if (userIdError)
+  const userRes = await getUserId(supabase);
+  if ("error" in userRes) {
+    if (userRes.error === "unauthorized")
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+  }
+  const { userId } = userRes;
 
   const url = new URL(req.url);
   const win = url.searchParams.get("window") || "7d";
@@ -43,11 +45,13 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const supabase = await createRouteHandlerClient();
-  const { userId, error: userIdError } = await getUserId(supabase);
-  if (userIdError === "unauthorized")
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-  if (userIdError)
+  const userRes = await getUserId(supabase);
+  if ("error" in userRes) {
+    if (userRes.error === "unauthorized")
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+  }
+  const { userId } = userRes;
 
   const body = await req.json().catch(() => ({}));
   const action = String(body.action || "Water").toLowerCase();

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import TaskRow from "@/components/TaskRow";
 import ThemeToggle from "@/components/ThemeToggle";
 import { TaskDTO } from "@/lib/types";
+import { createSupabaseClient } from "@/lib/supabase";
 import { motion } from "framer-motion";
 import {
   Select,
@@ -604,6 +605,14 @@ export function TimelineView() {
 }
 
 export function SettingsView() {
+  const supabase = useRef(createSupabaseClient());
+
+  async function handleSignOut() {
+    await supabase.current.auth.signOut();
+    document.cookie = "sb-access-token=; Path=/; Max-Age=0";
+    window.location.href = "/login";
+  }
+
   return (
     <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
       <header
@@ -638,6 +647,12 @@ export function SettingsView() {
             <div className="text-base font-medium">Theme</div>
             <ThemeToggle />
           </div>
+          <button
+            onClick={handleSignOut}
+            className="rounded-xl border bg-white shadow-sm p-4 text-left text-base font-medium dark:bg-neutral-800 dark:border-neutral-700"
+          >
+            Sign out
+          </button>
         </section>
       </main>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { createSupabaseClient } from "@/lib/supabase";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    try {
+      const supabase = createSupabaseClient();
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (error || !data.session) throw error || new Error("No session");
+      document.cookie = `sb-access-token=${data.session.access_token}; path=/; max-age=3600`;
+      window.location.href = "/app";
+    } catch (e: any) {
+      setError(e.message || "Login failed");
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4 p-4">
+        <h1 className="text-xl font-semibold">Log in</h1>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="w-full rounded border px-3 py-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="w-full rounded border px-3 py-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="w-full rounded bg-neutral-900 px-3 py-2 text-white"
+        >
+          Sign in
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,4 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import { cookies } from "next/headers";
 import type { Database } from "./supabase.types";
 
 function getSupabaseEnv() {
@@ -19,6 +18,7 @@ export function createSupabaseClient(): SupabaseClient<Database> {
 
 // Authenticated client helper for Route Handlers
 export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
+  const { cookies } = await import("next/headers");
   const { url, anonKey } = getSupabaseEnv();
   // `cookies()` is now asynchronous in Next 15 and must be awaited
   const cookieStore = await cookies();

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,0 +1,13 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./supabase.types";
+
+export function createSupabaseAdminClient(): SupabaseClient<Database> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error("Missing Supabase environment variables");
+  }
+  return createClient<Database>(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}


### PR DESCRIPTION
## Summary
- add Supabase admin client and placeholder sync API
- add email/password login page and sign-out option
- document Supabase service key and login flow

## Testing
- `npm test`
- `npm run build` *(fails: Type error in AppShell's TaskRow props)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ffd1b10083248a76efdb515037b3