### PR TITLE
Fix incorrect button closing tag in Settings view

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -647,10 +647,9 @@ export function SettingsView() {
               </Button>
               <Button variant="default" size="sm">
                 Import
-
-              </button>
-            </div>
-          </div>
+              </Button>
+            </CardContent>
+          </Card>
           <div className="rounded-xl border bg-white shadow-sm p-4 flex items-center justify-between dark:bg-neutral-800 dark:border-neutral-700">
             <div className="text-base font-medium">Theme</div>
             <ThemeToggle />
@@ -661,17 +660,6 @@ export function SettingsView() {
           >
             Sign out
           </button>
-
-              </Button>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="flex items-center justify-between">
-              <div className="text-base font-medium">Theme</div>
-              <ThemeToggle />
-            </CardContent>
-          </Card>
-
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- fix Settings view export/import section markup
- remove duplicated closing tags and theme block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a405d5147c8324b3da99bad2708f8f