### PR TITLE
feat: enable real-time task sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kay Maria – Developer Guide
 
-This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
+This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion with real-time task syncing across devices. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
 
 ## Quick Start
 1. Install dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
 
 - [ ] Multi-device sync
   - [x] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
-  - [ ] Real-time data sync across devices
+  - [x] Real-time data sync across devices
 - [ ] Regression tests
   - [ ] End-to-end test suite
   - [ ] Continuous integration pipeline

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -6,6 +6,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import { TaskDTO } from "@/lib/types";
 
 import { createSupabaseClient } from "@/lib/supabase";
+import { subscribeToTaskChanges } from "@/lib/realtime";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -195,6 +196,11 @@ export function TodayView() {
   useEffect(() => {
     refresh(taskWindow);
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToTaskChanges(() => refresh(taskWindow));
+    return () => unsubscribe();
+  }, [taskWindow]);
 
   useEffect(() => {
     if (

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,0 +1,17 @@
+import { createSupabaseClient } from "./supabase";
+
+export function subscribeToTaskChanges(onChange: () => void) {
+  const supabase = createSupabaseClient();
+  const channel = supabase
+    .channel("tasks-db-changes")
+    .on(
+      "postgres_changes",
+      { event: "*", schema: "public", table: "tasks" },
+      () => onChange()
+    )
+    .subscribe();
+
+  return () => {
+    supabase.removeChannel(channel);
+  };
+}


### PR DESCRIPTION
## Summary
- mark real-time data sync as complete in roadmap
- add Supabase realtime helper and hook into AppShell to refresh tasks
- document real-time syncing in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4061e7fa08324a9c04e2ecda3fca5