### PR TITLE
Add selectable time range to insights chart

### DIFF
--- a/app/api/insights/route.test.ts
+++ b/app/api/insights/route.test.ts
@@ -1,0 +1,90 @@
+import { GET } from './route';
+import { createRouteHandlerClient } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  createRouteHandlerClient: jest.fn(),
+}));
+
+describe('GET /api/insights', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  });
+
+  it('returns data for default range', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-03'));
+
+    const plantData = [
+      { created_at: '2024-05-01T10:00:00Z' },
+      { created_at: '2024-05-01T12:00:00Z' },
+    ];
+    const taskData = [{ due_at: '2024-05-02T00:00:00Z' }];
+
+    const mockPlantQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: plantData, error: null }),
+    };
+    const mockTaskQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: taskData, error: null }),
+    };
+    const mockFrom = jest.fn((table: string) =>
+      table === 'plants' ? mockPlantQuery : mockTaskQuery
+    );
+
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+      from: mockFrom,
+    });
+
+    const res = await GET(new Request('http://localhost/api/insights') as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.length).toBe(7);
+    expect(json).toContainEqual({ period: '2024-05-01', plantCount: 2, taskCount: 0 });
+    expect(json).toContainEqual({ period: '2024-05-02', plantCount: 0, taskCount: 1 });
+
+    jest.useRealTimers();
+  });
+
+  it('returns data for custom range', async () => {
+    const plantData = [{ created_at: '2024-05-01T10:00:00Z' }];
+    const taskData = [{ due_at: '2024-05-02T00:00:00Z' }];
+
+    const mockPlantQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: plantData, error: null }),
+    };
+    const mockTaskQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: taskData, error: null }),
+    };
+    const mockFrom = jest.fn((table: string) =>
+      table === 'plants' ? mockPlantQuery : mockTaskQuery
+    );
+
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+      from: mockFrom,
+    });
+
+    const res = await GET(
+      new Request('http://localhost/api/insights?start=2024-05-01&end=2024-05-02') as any
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([
+      { period: '2024-05-01', plantCount: 1, taskCount: 0 },
+      { period: '2024-05-02', plantCount: 0, taskCount: 1 },
+    ]);
+  });
+});

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -2,7 +2,27 @@ import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase";
 import { getUserId } from "@/lib/getUserId";
 
-export async function GET() {
+type InsightPoint = {
+  period: string;
+  plantCount: number;
+  taskCount: number;
+};
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const startParam = url.searchParams.get("start");
+  const endParam = url.searchParams.get("end");
+
+  const endDate = endParam ? new Date(endParam) : new Date();
+  const startDate = startParam ? new Date(startParam) : new Date(endDate);
+
+  // Default to last 7 days if start not provided
+  if (!startParam) startDate.setDate(endDate.getDate() - 6);
+
+  // Normalize to start/end of day boundaries
+  startDate.setHours(0, 0, 0, 0);
+  endDate.setHours(23, 59, 59, 999);
+
   const supabase = await createRouteHandlerClient();
   const { userId, error: userIdError } = await getUserId(supabase);
   if (userIdError === "unauthorized")
@@ -10,15 +30,22 @@ export async function GET() {
   if (userIdError)
     return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
 
+  const startIso = startDate.toISOString();
+  const endIso = endDate.toISOString();
+
   const [plantRes, taskRes] = await Promise.all([
     supabase
       .from("plants")
-      .select("id", { count: "exact", head: true })
-      .eq("user_id", userId),
+      .select("created_at")
+      .eq("user_id", userId)
+      .gte("created_at", startIso)
+      .lte("created_at", endIso),
     supabase
       .from("tasks")
-      .select("id", { count: "exact", head: true })
-      .eq("user_id", userId),
+      .select("due_at")
+      .eq("user_id", userId)
+      .gte("due_at", startIso)
+      .lte("due_at", endIso),
   ]);
 
   if (plantRes.error) {
@@ -30,8 +57,31 @@ export async function GET() {
     return NextResponse.json({ error: "server" }, { status: 500 });
   }
 
-  return NextResponse.json({
-    plantCount: plantRes.count ?? 0,
-    taskCount: taskRes.count ?? 0,
+  // Prepare daily buckets
+  const points: InsightPoint[] = [];
+  for (
+    let d = new Date(startDate);
+    d <= endDate;
+    d.setDate(d.getDate() + 1)
+  ) {
+    points.push({
+      period: d.toISOString().slice(0, 10),
+      plantCount: 0,
+      taskCount: 0,
+    });
+  }
+  const map = new Map(points.map((p) => [p.period, p]));
+
+  plantRes.data?.forEach((row: any) => {
+    const key = row.created_at.slice(0, 10);
+    const p = map.get(key);
+    if (p) p.plantCount++;
   });
+  taskRes.data?.forEach((row: any) => {
+    const key = row.due_at.slice(0, 10);
+    const p = map.get(key);
+    if (p) p.taskCount++;
+  });
+
+  return NextResponse.json(points);
 }


### PR DESCRIPTION
## Summary
- add date range controls to insights view and plot plants/tasks trends
- extend insights API to return daily counts for selected range
- test API and UI for default and custom date ranges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a406713be883248cf747b6f82cfcfe