### PR TITLE
Fix task due date mapping and test plant serialization

### DIFF
--- a/app/api/plants/[id]/route.test.ts
+++ b/app/api/plants/[id]/route.test.ts
@@ -1,14 +1,34 @@
-import { PATCH, DELETE } from './route';
-import { updatePlant, deletePlant } from '@/lib/prisma/plants';
+import { GET, PATCH, DELETE } from './route';
+import {
+  getPlant,
+  getComputedWaterInfo,
+  updatePlant,
+  deletePlant,
+} from '@/lib/prisma/plants';
 
 jest.mock('@/lib/prisma/plants', () => ({
+  getPlant: jest.fn(),
+  getComputedWaterInfo: jest.fn(),
   updatePlant: jest.fn(),
   deletePlant: jest.fn(),
 }));
 
-describe('PATCH/DELETE /api/plants/[id]', () => {
+describe('GET/PATCH/DELETE /api/plants/[id]', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+  });
+
+  it('returns plant with serialized dates', async () => {
+    (getPlant as jest.Mock).mockResolvedValue({
+      id: 'p1',
+      name: 'Test',
+      lastWateredAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+    (getComputedWaterInfo as jest.Mock).mockReturnValue({});
+    const res = await GET({} as any, { params: { id: 'p1' } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.lastWateredAt).toBe('2024-01-01T00:00:00.000Z');
   });
 
   it('updates existing plant', async () => {

--- a/app/api/plants/route.test.ts
+++ b/app/api/plants/route.test.ts
@@ -22,13 +22,27 @@ describe('GET/POST /api/plants', () => {
   });
 
   it('returns plants', async () => {
-    const plants = [{ id: 'p1', name: 'Fiddle' }];
+    const plants = [
+      {
+        id: 'p1',
+        name: 'Fiddle',
+        lastWateredAt: new Date('2024-01-01T00:00:00.000Z'),
+        lastFertilizedAt: new Date('2024-01-02T00:00:00.000Z'),
+      },
+    ];
     (listPlants as jest.Mock).mockResolvedValue(plants);
 
     const res = await GET();
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toEqual(plants);
+    expect(json).toEqual([
+      {
+        id: 'p1',
+        name: 'Fiddle',
+        lastWateredAt: '2024-01-01T00:00:00.000Z',
+        lastFertilizedAt: '2024-01-02T00:00:00.000Z',
+      },
+    ]);
     expect(listPlants).toHaveBeenCalled();
   });
 
@@ -83,7 +97,12 @@ describe('GET/POST /api/plants', () => {
   });
 
   it('passes last care dates when provided', async () => {
-    const newPlant = { id: 'p_new', name: 'New Plant' };
+    const newPlant = {
+      id: 'p_new',
+      name: 'New Plant',
+      lastWateredAt: new Date('2024-01-01T00:00:00.000Z'),
+      lastFertilizedAt: new Date('2024-01-02T00:00:00.000Z'),
+    };
     (createPlant as jest.Mock).mockResolvedValue(newPlant);
 
     const mockSupabase = { auth: { getUser: jest.fn() } };
@@ -101,12 +120,14 @@ describe('GET/POST /api/plants', () => {
 
     const res = await POST(req as any);
     expect(res.status).toBe(201);
-    await res.json();
+    const json = await res.json();
     expect(createPlant).toHaveBeenCalledWith('user-1', {
       name: 'New Plant',
       lastWateredAt: '2024-01-01T00:00:00.000Z',
       lastFertilizedAt: '2024-01-02T00:00:00.000Z',
     });
+    expect(json.lastWateredAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(json.lastFertilizedAt).toBe('2024-01-02T00:00:00.000Z');
   });
 
   it('returns 503 when env vars missing', async () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,7 @@ model Task {
   userId     String    @map("user_id") @db.Uuid
   plantId    String    @map("plant_id") @db.Uuid
   type       String
-  dueDate    DateTime  @map("due_date")
+  dueAt      DateTime  @map("due_at")
   lastDoneAt DateTime? @map("last_done_at")
   notes      String?
   createdAt  DateTime  @default(now()) @map("created_at")


### PR DESCRIPTION
## Summary
- Correct task due date mapping in Prisma schema using `@map("due_at")`
- Add tests to ensure plant date fields serialize/deserialise correctly on list and create endpoints
- Cover plant detail endpoint with serialization test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a407f996208324a1486f7ba600f576