### PR TITLE
feat: add task and plant metrics to insights

### DIFF
--- a/app/api/insights/route.test.ts
+++ b/app/api/insights/route.test.ts
@@ -19,7 +19,12 @@ describe('GET /api/insights', () => {
       { created_at: '2024-05-01T10:00:00Z' },
       { created_at: '2024-05-01T12:00:00Z' },
     ];
-    const taskData = [{ due_at: '2024-05-02T00:00:00Z' }];
+    const completedTaskData = [
+      { last_done_at: '2024-05-02T03:00:00Z' },
+    ];
+    const dueTaskData = [
+      { due_at: '2024-05-02T00:00:00Z', last_done_at: null },
+    ];
 
     const mockPlantQuery = {
       select: jest.fn().mockReturnThis(),
@@ -27,15 +32,24 @@ describe('GET /api/insights', () => {
       gte: jest.fn().mockReturnThis(),
       lte: jest.fn().mockResolvedValue({ data: plantData, error: null }),
     };
-    const mockTaskQuery = {
+    const mockCompletedTaskQuery = {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       gte: jest.fn().mockReturnThis(),
-      lte: jest.fn().mockResolvedValue({ data: taskData, error: null }),
+      lte: jest.fn().mockResolvedValue({ data: completedTaskData, error: null }),
     };
-    const mockFrom = jest.fn((table: string) =>
-      table === 'plants' ? mockPlantQuery : mockTaskQuery
-    );
+    const mockDueTaskQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: dueTaskData, error: null }),
+    };
+    let taskCall = 0;
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'plants') return mockPlantQuery;
+      taskCall++;
+      return taskCall === 1 ? mockCompletedTaskQuery : mockDueTaskQuery;
+    });
 
     (createRouteHandlerClient as jest.Mock).mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
@@ -46,15 +60,28 @@ describe('GET /api/insights', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.length).toBe(7);
-    expect(json).toContainEqual({ period: '2024-05-01', plantCount: 2, taskCount: 0 });
-    expect(json).toContainEqual({ period: '2024-05-02', plantCount: 0, taskCount: 1 });
+    expect(json).toContainEqual({
+      period: '2024-05-01',
+      newPlantCount: 2,
+      completedTaskCount: 0,
+      overdueTaskCount: 0,
+    });
+    expect(json).toContainEqual({
+      period: '2024-05-02',
+      newPlantCount: 0,
+      completedTaskCount: 1,
+      overdueTaskCount: 1,
+    });
 
     jest.useRealTimers();
   });
 
   it('returns data for custom range', async () => {
     const plantData = [{ created_at: '2024-05-01T10:00:00Z' }];
-    const taskData = [{ due_at: '2024-05-02T00:00:00Z' }];
+    const completedTaskData = [{ last_done_at: '2024-05-02T00:00:00Z' }];
+    const dueTaskData = [
+      { due_at: '2024-05-02T00:00:00Z', last_done_at: null },
+    ];
 
     const mockPlantQuery = {
       select: jest.fn().mockReturnThis(),
@@ -62,15 +89,24 @@ describe('GET /api/insights', () => {
       gte: jest.fn().mockReturnThis(),
       lte: jest.fn().mockResolvedValue({ data: plantData, error: null }),
     };
-    const mockTaskQuery = {
+    const mockCompletedTaskQuery = {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       gte: jest.fn().mockReturnThis(),
-      lte: jest.fn().mockResolvedValue({ data: taskData, error: null }),
+      lte: jest.fn().mockResolvedValue({ data: completedTaskData, error: null }),
     };
-    const mockFrom = jest.fn((table: string) =>
-      table === 'plants' ? mockPlantQuery : mockTaskQuery
-    );
+    const mockDueTaskQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockResolvedValue({ data: dueTaskData, error: null }),
+    };
+    let taskCall = 0;
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'plants') return mockPlantQuery;
+      taskCall++;
+      return taskCall === 1 ? mockCompletedTaskQuery : mockDueTaskQuery;
+    });
 
     (createRouteHandlerClient as jest.Mock).mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
@@ -83,8 +119,18 @@ describe('GET /api/insights', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toEqual([
-      { period: '2024-05-01', plantCount: 1, taskCount: 0 },
-      { period: '2024-05-02', plantCount: 0, taskCount: 1 },
+      {
+        period: '2024-05-01',
+        newPlantCount: 1,
+        completedTaskCount: 0,
+        overdueTaskCount: 0,
+      },
+      {
+        period: '2024-05-02',
+        newPlantCount: 0,
+        completedTaskCount: 1,
+        overdueTaskCount: 1,
+      },
     ]);
   });
 });

--- a/app/app/insights/InsightsView.test.tsx
+++ b/app/app/insights/InsightsView.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InsightsView from './InsightsView';
 
@@ -14,9 +14,24 @@ describe('InsightsView', () => {
       ok: true,
       json: () =>
         Promise.resolve([
-          { period: '2024-05-01', plantCount: 1, taskCount: 2 },
-          { period: '2024-05-02', plantCount: 0, taskCount: 1 },
-          { period: '2024-05-03', plantCount: 0, taskCount: 0 },
+          {
+            period: '2024-05-01',
+            newPlantCount: 1,
+            completedTaskCount: 2,
+            overdueTaskCount: 0,
+          },
+          {
+            period: '2024-05-02',
+            newPlantCount: 0,
+            completedTaskCount: 1,
+            overdueTaskCount: 1,
+          },
+          {
+            period: '2024-05-03',
+            newPlantCount: 0,
+            completedTaskCount: 0,
+            overdueTaskCount: 2,
+          },
         ]),
     }) as any;
   });
@@ -24,6 +39,16 @@ describe('InsightsView', () => {
   afterEach(() => {
     jest.useRealTimers();
     (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('shows totals for metrics', async () => {
+    render(<InsightsView />);
+    const completed = await screen.findByText(/Completed Tasks/i);
+    expect(within(completed.parentElement!).getByText('3')).toBeInTheDocument();
+    const overdue = screen.getByText(/Overdue Tasks/i);
+    expect(within(overdue.parentElement!).getByText('3')).toBeInTheDocument();
+    const plants = screen.getByText(/New Plants/i);
+    expect(within(plants.parentElement!).getByText('1')).toBeInTheDocument();
   });
 
   it('fetches default range', async () => {

--- a/app/app/insights/InsightsView.tsx
+++ b/app/app/insights/InsightsView.tsx
@@ -21,7 +21,12 @@ ChartJS.register(
   Legend
 );
 
-type InsightPoint = { period: string; plantCount: number; taskCount: number };
+type InsightPoint = {
+  period: string;
+  newPlantCount: number;
+  completedTaskCount: number;
+  overdueTaskCount: number;
+};
 
 export default function InsightsView() {
   const [start, setStart] = useState(() => {
@@ -49,23 +54,33 @@ export default function InsightsView() {
     if (start && end) load();
   }, [start, end]);
 
-  const totalPlants = data?.reduce((s, d) => s + d.plantCount, 0) ?? 0;
-  const totalTasks = data?.reduce((s, d) => s + d.taskCount, 0) ?? 0;
+  const totalNewPlants =
+    data?.reduce((s, d) => s + d.newPlantCount, 0) ?? 0;
+  const totalCompletedTasks =
+    data?.reduce((s, d) => s + d.completedTaskCount, 0) ?? 0;
+  const totalOverdueTasks =
+    data?.reduce((s, d) => s + d.overdueTaskCount, 0) ?? 0;
 
   const chartData = {
     labels: data ? data.map((d) => d.period) : [],
     datasets: [
       {
-        label: "Plants",
-        data: data ? data.map((d) => d.plantCount) : [],
-        borderColor: "#86efac",
-        backgroundColor: "rgba(134,239,172,0.5)",
-      },
-      {
-        label: "Tasks",
-        data: data ? data.map((d) => d.taskCount) : [],
+        label: "Completed Tasks",
+        data: data ? data.map((d) => d.completedTaskCount) : [],
         borderColor: "#93c5fd",
         backgroundColor: "rgba(147,197,253,0.5)",
+      },
+      {
+        label: "Overdue Tasks",
+        data: data ? data.map((d) => d.overdueTaskCount) : [],
+        borderColor: "#fca5a5",
+        backgroundColor: "rgba(252,165,165,0.5)",
+      },
+      {
+        label: "New Plants",
+        data: data ? data.map((d) => d.newPlantCount) : [],
+        borderColor: "#86efac",
+        backgroundColor: "rgba(134,239,172,0.5)",
       },
     ],
   };
@@ -105,14 +120,18 @@ export default function InsightsView() {
                 />
               </label>
             </div>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
-                <div className="text-sm text-neutral-500">Plants</div>
-                <div className="text-2xl font-bold">{totalPlants}</div>
+                <div className="text-sm text-neutral-500">Completed Tasks</div>
+                <div className="text-2xl font-bold">{totalCompletedTasks}</div>
               </div>
               <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
-                <div className="text-sm text-neutral-500">Tasks</div>
-                <div className="text-2xl font-bold">{totalTasks}</div>
+                <div className="text-sm text-neutral-500">Overdue Tasks</div>
+                <div className="text-2xl font-bold">{totalOverdueTasks}</div>
+              </div>
+              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+                <div className="text-sm text-neutral-500">New Plants</div>
+                <div className="text-2xl font-bold">{totalNewPlants}</div>
               </div>
             </div>
             <div className="rounded-xl border bg-white shadow-sm p-4">


### PR DESCRIPTION
## Summary
- expand `/api/insights` to provide newPlantCount, completedTaskCount, and overdueTaskCount metrics
- update insights view to visualize the new statistics with cards and chart series
- extend tests for API and view to cover the additional data points

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a407d8a3f48324a94b88cb6380c190