### PR TITLE
Compute next due for plant tasks

### DIFF
--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
     const params = await (ctx as any).params;
     const plant = await getPlant(params.id);
     if (!plant) return NextResponse.json({ error: "Not found" }, { status: 404 });
-    const water = getComputedWaterInfo(plant);
+    const water = await getComputedWaterInfo(plant);
     return NextResponse.json({ ...plant, water });
   } catch (e: any) {
     console.error("GET /api/plants/[id] failed:", e);

--- a/lib/prisma/plants.test.ts
+++ b/lib/prisma/plants.test.ts
@@ -1,0 +1,39 @@
+var mTask: { findFirst: jest.Mock };
+jest.mock('@prisma/client', () => {
+  mTask = { findFirst: jest.fn() };
+  return { PrismaClient: jest.fn(() => ({ task: mTask })) };
+});
+
+import { getComputedWaterInfo } from './plants';
+
+describe('getComputedWaterInfo', () => {
+  beforeEach(() => {
+    mTask.findFirst.mockReset();
+  });
+
+  it('returns next due and last done from task', async () => {
+    mTask.findFirst.mockResolvedValue({
+      dueDate: new Date('2024-05-10T00:00:00Z'),
+      lastDoneAt: new Date('2024-05-01T00:00:00Z'),
+    });
+    const res = await getComputedWaterInfo({ id: 'p1' } as any);
+    expect(res).toEqual({
+      lastDoneAt: '2024-05-01T00:00:00.000Z',
+      nextDue: '2024-05-10T00:00:00.000Z',
+    });
+    expect(mTask.findFirst).toHaveBeenCalledWith({
+      where: { plantId: 'p1', type: 'water' },
+      orderBy: { dueDate: 'asc' },
+    });
+  });
+
+  it('falls back to plant lastWateredAt when no task', async () => {
+    mTask.findFirst.mockResolvedValue(null);
+    const plant = { id: 'p1', lastWateredAt: new Date('2024-04-01T00:00:00Z') } as any;
+    const res = await getComputedWaterInfo(plant);
+    expect(res).toEqual({
+      lastDoneAt: '2024-04-01T00:00:00.000Z',
+      nextDue: null,
+    });
+  });
+});

--- a/lib/prisma/plants.ts
+++ b/lib/prisma/plants.ts
@@ -94,7 +94,26 @@ export async function deletePlant(id: string): Promise<boolean> {
   }
 }
 
-export function getComputedWaterInfo(_plant: Plant): Record<string, never> {
-  return {};
+export async function getComputedWaterInfo(plant: Plant) {
+  const task = await prisma.task.findFirst({
+    where: { plantId: plant.id, type: "water" },
+    orderBy: { dueDate: "asc" },
+  });
+  if (!task) {
+    return {
+      lastDoneAt: plant.lastWateredAt
+        ? plant.lastWateredAt.toISOString()
+        : null,
+      nextDue: null,
+    };
+  }
+  return {
+    lastDoneAt: task.lastDoneAt
+      ? task.lastDoneAt.toISOString()
+      : plant.lastWateredAt
+      ? plant.lastWateredAt.toISOString()
+      : null,
+    nextDue: task.dueDate.toISOString(),
+  };
 }
 


### PR DESCRIPTION
## Summary
- choose column-based timestamps to track recurring plant care
- expose next watering schedule via `GET /api/plants/[id]`
- test calculation of next due watering from task records

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a408126e508324905021cd64428175