### PR TITLE
Use SWR for plant list with reactive revalidation

### DIFF
--- a/app/app/plants/usePlants.test.tsx
+++ b/app/app/plants/usePlants.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import usePlants from './usePlants';
+import useSWR from 'swr';
+
+jest.mock('swr');
+const mockUseSWR = useSWR as unknown as jest.Mock;
+
+describe('usePlants', () => {
+  it('returns data on success', () => {
+    mockUseSWR.mockReturnValue({
+      data: [{ id: '1', name: 'Fern' }],
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+    const { result } = renderHook(() => usePlants());
+    expect(result.current.plants).toEqual([{ id: '1', name: 'Fern' }]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('indicates loading state', () => {
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: jest.fn(),
+    });
+    const { result } = renderHook(() => usePlants());
+    expect(result.current.plants).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns error state', () => {
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: new Error('failed'),
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+    const { result } = renderHook(() => usePlants());
+    expect(result.current.plants).toBeNull();
+    expect(result.current.error).toBe('failed');
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/app/app/plants/usePlants.ts
+++ b/app/app/plants/usePlants.ts
@@ -1,0 +1,30 @@
+import useSWR from 'swr';
+
+export type Plant = { id: string; name: string; room?: string; species?: string };
+
+async function fetcher(url: string): Promise<Plant[]> {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export default function usePlants() {
+  const { data, error, isLoading, mutate } = useSWR<Plant[]>(
+    '/api/plants',
+    fetcher,
+    {
+      revalidateOnFocus: true,
+      errorRetryInterval: 5000,
+      errorRetryCount: 3,
+    },
+  );
+
+  return {
+    plants: data ?? null,
+    error: error instanceof Error ? error.message : null,
+    isLoading,
+    mutate,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "18.2.0",
+        "swr": "^2.3.6",
         "zod": "3.23.8"
       },
       "devDependencies": {
@@ -3692,7 +3693,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6720,6 +6720,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "react": "18.2.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.2.0",
+    "swr": "^2.3.6",
     "zod": "3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.11",
@@ -41,7 +43,6 @@
     "prisma": "^6.14.0",
     "tailwindcss": "^4.1.12",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.0",
-    "@playwright/test": "^1.54.2"
+    "typescript": "^5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace manual effect+fetch with `usePlants` hook built on SWR
- revalidate on window focus and retry on errors for more reactive UI
- expose loading and error states and refresh via `mutate`
- add unit tests mocking SWR to cover success, loading and error scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40a7d22f08324bf144f71c1558945