### PR TITLE
Clarify AI plan suggestions and fallback behavior

### DIFF
--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -197,6 +197,9 @@ export function BasicsFields({
           }}
           inputRef={nameInputRef}
         />
+        <p className="hint">
+          Species helps personalize care. If unknown, generic tips apply.
+        </p>
       </Field>
 
       <Field label="Room">
@@ -467,7 +470,10 @@ export function EnvironmentFields({
             </div>
           )}
         </div>
-        <p className="hint">Used to tailor intervals based on local conditions.</p>
+        <p className="hint">
+          Used to tailor intervals based on local conditions. Without a location
+          we'll use standard intervals.
+        </p>
       </Field>
 
       <button
@@ -594,7 +600,7 @@ export function CarePlanFields({
         setSuggest(json);
         onPlanModeChange?.('ai');
       } catch (e: any) {
-        setSuggestError(e?.message || 'Could not get suggestions.');
+        setSuggestError("Couldn't reach the server. Your info is safe—try again.");
       } finally {
         setLoadingSuggest(false);
       }
@@ -638,7 +644,9 @@ export function CarePlanFields({
     <div className="p-6 space-y-6">
       {showSuggest && (
         <div className="rounded-xl border p-3 bg-neutral-50">
-          <div className="text-sm font-medium mb-2">Suggested plan</div>
+          <div className="text-sm font-medium mb-2">
+            AI-generated plan — Review and customize before saving.
+          </div>
           {loadingSuggest && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 animate-pulse">
               <div className="h-20 rounded-lg bg-neutral-200" />

--- a/components/SpeciesAutosuggest.test.tsx
+++ b/components/SpeciesAutosuggest.test.tsx
@@ -22,7 +22,9 @@ describe('SpeciesAutosuggest', () => {
     });
 
     expect(
-      await screen.findByText('No suggestions right now. You can still proceed.')
+      await screen.findByText(
+        "Couldn't reach the server. Your info is safe—try again."
+      )
     ).toBeInTheDocument();
 
     (global as any).fetch = oldFetch;

--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -179,7 +179,7 @@ export default function SpeciesAutosuggest({
                 <>
                   {error && (
                     <li className="px-3 py-2 text-sm text-neutral-500 pointer-events-none">
-                      No suggestions right now. You can still proceed.
+                      Couldn't reach the server. Your info is safe—try again.
                     </li>
                   )}
                   {suggestions.map((s) => (


### PR DESCRIPTION
## Summary
- Clarify the AI-generated care plan banner with a review reminder
- Add hints for when species or location data is missing
- Show a friendly server error message in species and care plan suggestions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a40b38c4348324b7bbece2b8f0bfb6