### PR TITLE
feat: add insights skeleton loading state

### DIFF
--- a/app/app/insights/InsightsSkeleton.tsx
+++ b/app/app/insights/InsightsSkeleton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+export default function InsightsSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      data-testid="insights-skeleton"
+      className="space-y-4 animate-pulse"
+    >
+      <div className="flex gap-2">
+        <div className="h-6 w-32 rounded bg-neutral-200" />
+        <div className="h-6 w-32 rounded bg-neutral-200" />
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border bg-white shadow-sm p-4 space-y-2"
+          >
+            <div className="h-4 w-3/4 bg-neutral-200 rounded" />
+            <div className="h-6 w-1/2 bg-neutral-200 rounded" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-xl border bg-white shadow-sm p-4">
+        <div className="h-48 bg-neutral-200 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/app/app/insights/InsightsView.test.tsx
+++ b/app/app/insights/InsightsView.test.tsx
@@ -74,4 +74,36 @@ describe('InsightsView', () => {
     expect(url).toContain('start=2024-05-01');
     expect(url).toContain('end=2024-05-02');
   });
+
+  it('shows skeleton before data loads', async () => {
+    let resolveFetch: any;
+    (global.fetch as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    render(<InsightsView />);
+
+    expect(screen.getByTestId('insights-skeleton')).toBeInTheDocument();
+
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            period: '2024-05-01',
+            newPlantCount: 1,
+            completedTaskCount: 2,
+            overdueTaskCount: 0,
+          },
+        ]),
+    });
+
+    await screen.findByText(/Completed Tasks/i);
+    await waitFor(() =>
+      expect(screen.queryByTestId('insights-skeleton')).not.toBeInTheDocument()
+    );
+  });
 });

--- a/app/app/insights/InsightsView.tsx
+++ b/app/app/insights/InsightsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import InsightsSkeleton from "./InsightsSkeleton";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -96,7 +97,7 @@ export default function InsightsView() {
           </div>
         )}
 
-        {!data && !err && <div className="text-sm text-neutral-500">Loading…</div>}
+        {!data && !err && <InsightsSkeleton />}
 
         {data && (
           <>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,5 +1,12 @@
 export default function Loading() {
   return (
-    <div className="p-4 text-center">Loading...</div>
+    <div
+      className="p-4 flex justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="h-6 w-6 border-4 border-neutral-300 border-t-neutral-600 rounded-full animate-spin" />
+      <span className="sr-only">Loading...</span>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace InsightsView text placeholder with layout-matching skeleton and global spinner
- mark skeletons with `aria-busy` for better accessibility
- test that the skeleton renders before data resolves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40c4b5fe083248cecfd1b33c953ff