### PR TITLE
Add shimmering timeline skeleton for loading state

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -29,6 +29,7 @@ import {
   X,
   Filter as FilterIcon,
 } from "lucide-react";
+import TimelineSkeleton from "./timeline/TimelineSkeleton";
 
 const DEFAULT_TASK_WINDOW_DAYS = (() => {
   const parsed = parseInt(
@@ -664,7 +665,7 @@ export function TimelineView() {
           <div className="text-sm px-4 py-2">
             {eventsErr && <div className="py-3 text-red-600">{eventsErr}</div>}
             {!eventsErr && events.length === 0 && eventsLoading && (
-              <div className="py-3 text-neutral-500">Loading…</div>
+              <TimelineSkeleton />
             )}
             {!eventsErr && !eventsLoading && dayBuckets.length === 0 && (
               <div className="py-3 text-neutral-500">No events</div>
@@ -699,7 +700,7 @@ export function TimelineView() {
             {!eventsErr && hasMore && (
               <div className="py-3 text-center">
                 {eventsLoading ? (
-                  <div className="text-neutral-500">Loading…</div>
+                  <TimelineSkeleton />
                 ) : (
                   <button
                     onClick={loadMore}

--- a/app/app/timeline/TimelineSkeleton.tsx
+++ b/app/app/timeline/TimelineSkeleton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+
+export function TimelineSkeleton() {
+  return (
+    <div className="py-3">
+      <div className="hidden motion-safe:block space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-4 rounded bg-neutral-200 relative overflow-hidden"
+          >
+            <div
+              className="absolute inset-0 bg-gradient-to-r from-transparent via-white/60 to-transparent"
+              style={{ animation: "shimmer 1.5s infinite" }}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="text-neutral-500 block motion-safe:hidden">Loading…</div>
+    </div>
+  );
+}
+
+export default TimelineSkeleton;
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
## Summary
- add shimmer-based `TimelineSkeleton` component
- use `TimelineSkeleton` during timeline loads with reduced-motion text fallback
- define global `shimmer` keyframes for skeleton animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40c1d31348324b8e7ee8d9b811dc6