### PR TITLE
Add comprehensive plant input validation and room ownership checks

### DIFF
--- a/app/api/plants/[id]/route.test.ts
+++ b/app/api/plants/[id]/route.test.ts
@@ -5,6 +5,7 @@ import {
   updatePlant,
   deletePlant,
 } from '@/lib/prisma/plants';
+import { createRouteHandlerClient } from '@/lib/supabase';
 
 jest.mock('@/lib/prisma/plants', () => ({
   getPlant: jest.fn(),
@@ -13,9 +14,26 @@ jest.mock('@/lib/prisma/plants', () => ({
   deletePlant: jest.fn(),
 }));
 
+jest.mock('@/lib/supabase', () => ({
+  createRouteHandlerClient: jest.fn(),
+}));
+
+function makeSupabase() {
+  return {
+    auth: {
+      getUser: jest
+        .fn()
+        .mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    },
+    from: jest.fn(() => ({ select: jest.fn().mockReturnThis(), eq: jest.fn().mockReturnThis(), single: jest.fn().mockResolvedValue({ data: { id: 'r1' }, error: null }) })),
+  } as any;
+}
+
 describe('GET/PATCH/DELETE /api/plants/[id]', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
   });
 
   it('returns plant with serialized dates', async () => {
@@ -33,6 +51,8 @@ describe('GET/PATCH/DELETE /api/plants/[id]', () => {
 
   it('updates existing plant', async () => {
     (updatePlant as jest.Mock).mockResolvedValue({ id: 'p1', name: 'Updated' });
+    const mockSupabase = makeSupabase();
+    (createRouteHandlerClient as jest.Mock).mockResolvedValue(mockSupabase);
     const req = new Request('http://localhost/api/plants/p1', {
       method: 'PATCH',
       body: JSON.stringify({ name: 'Updated' }),

--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -5,6 +5,9 @@ import {
   updatePlant,
   deletePlant,
 } from "@/lib/prisma/plants";
+import { createRouteHandlerClient } from "@/lib/supabase";
+import { getUserId } from "@/lib/getUserId";
+import { plantInputSchema } from "@/lib/plantInputSchema";
 
 // In Next 15, params may be a Promise — await it.
 export async function GET(
@@ -23,16 +26,38 @@ export async function GET(
   }
 }
 
-export async function PATCH(
-  req: Request,
-  ctx: any
-) {
+export async function PATCH(req: Request, ctx: any) {
   try {
     const params = await (ctx as any).params;
+    const supabase = await createRouteHandlerClient();
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized")
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+    const { userId } = userRes;
+
     const body = await req.json().catch(() => ({}));
-    const { rules, ...rest } = body;
+    const parsed = plantInputSchema.partial().safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "invalid" }, { status: 400 });
+    }
+    const { roomId, rules, ...rest } = parsed.data;
+    if (roomId) {
+      const { data: room } = await supabase
+        .from("rooms")
+        .select("id")
+        .eq("id", roomId)
+        .eq("user_id", userId)
+        .single();
+      if (!room) {
+        return NextResponse.json({ error: "invalid room" }, { status: 400 });
+      }
+    }
     const updated = await updatePlant(params.id, {
       ...rest,
+      ...(roomId ? { roomId } : {}),
       ...(rules ? { carePlan: rules } : {}),
     });
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -12,7 +12,8 @@ import {
   PlantFormValues,
   plantValuesToSubmit,
 } from './PlantForm';
-import { plantFormSchema, plantFieldSchemas } from '@/lib/plantFormSchema';
+import { plantFieldSchemas } from '@/lib/plantFormSchema';
+import { plantInputSchema } from '@/lib/plantInputSchema';
 import type { AiCareSuggestion } from '@/lib/aiCare';
 
 type PlanSource =
@@ -73,7 +74,9 @@ export default function AddPlantModal({
     light: string;
   } | null>(null);
   const [toast, setToast] = useState<string | null>(null);
-  const canSubmit = values ? plantFormSchema.safeParse(values).success : false;
+  const canSubmit = values
+    ? plantInputSchema.safeParse(plantValuesToSubmit(values)).success
+    : false;
   const basicsValid = values
     ? plantFieldSchemas.name.safeParse(values.name).success &&
       plantFieldSchemas.roomId.safeParse(values.roomId).success

--- a/lib/plantFormSchema.ts
+++ b/lib/plantFormSchema.ts
@@ -3,9 +3,18 @@ import { z } from 'zod';
 export const plantFieldSchemas = {
   name: z.string().trim().min(1, 'Enter a plant name.'),
   roomId: z.string().min(1, 'Choose a room or add one.'),
-  waterEvery: z.coerce.number().min(1, 'Must be at least 1 day'),
-  waterAmount: z.coerce.number().min(10, 'Must be at least 10 ml'),
-  fertEvery: z.coerce.number().min(1, 'Must be at least 1 day'),
+  waterEvery: z
+    .coerce.number()
+    .min(1, 'Must be at least 1 day')
+    .max(365, 'Must be at most 365 days'),
+  waterAmount: z
+    .coerce.number()
+    .min(10, 'Must be at least 10 ml')
+    .max(10000, 'Must be at most 10000 ml'),
+  fertEvery: z
+    .coerce.number()
+    .min(1, 'Must be at least 1 day')
+    .max(365, 'Must be at most 365 days'),
   lastWatered: z.coerce.date({ invalid_type_error: 'Enter a valid date' }),
   lastFertilized: z.coerce.date({ invalid_type_error: 'Enter a valid date' }),
 };

--- a/lib/plantInputSchema.ts
+++ b/lib/plantInputSchema.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { SPECIES } from './species';
+
+export function normalizeSpecies(raw: string | undefined | null): string | undefined {
+  if (!raw) return undefined;
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+const allowedSpecies = new Set(
+  SPECIES.map((s) => normalizeSpecies(s.species)!)
+);
+allowedSpecies.add('custom');
+allowedSpecies.add('unknown');
+
+const potMaterials = ['Plastic', 'Terracotta', 'Ceramic'] as const;
+const lightLevels = ['Low', 'Medium', 'Bright'] as const;
+const drainageLevels = ['poor', 'ok', 'great'] as const;
+
+export const plantInputSchema = z.object({
+  name: z.string().trim().min(1),
+  roomId: z.string().min(1),
+  species: z
+    .string()
+    .optional()
+    .transform((v) => normalizeSpecies(v))
+    .refine((v) => v === undefined || allowedSpecies.has(v), {
+      message: 'invalid species',
+    }),
+  potSize: z.string().trim().min(1),
+  potMaterial: z.enum(potMaterials),
+  lightLevel: z.enum(lightLevels),
+  indoor: z.boolean(),
+  soilType: z.string().trim().optional(),
+  drainage: z.enum(drainageLevels),
+  lat: z.number().min(-90).max(90).optional(),
+  lon: z.number().min(-180).max(180).optional(),
+  carePlanSource: z.string().trim().optional(),
+  aiModel: z.string().trim().optional(),
+  aiVersion: z.string().trim().optional(),
+  presetId: z.string().trim().optional(),
+  lastWateredAt: z.string().datetime().optional(),
+  lastFertilizedAt: z.string().datetime().optional(),
+  rules: z
+    .array(
+      z.object({
+        type: z.enum(['water', 'fertilize']),
+        intervalDays: z.number().int().min(1).max(365),
+        amountMl: z.number().int().min(10).max(10000).optional(),
+        formula: z.string().trim().optional(),
+      })
+    )
+    .optional(),
+});
+
+export type PlantInput = z.infer<typeof plantInputSchema>;
+export const allowedPotMaterials = potMaterials;
+export const allowedLightLevels = lightLevels;
+export const allowedDrainage = drainageLevels;
+export const allowedSpeciesSlugs = allowedSpecies;


### PR DESCRIPTION
## Summary
- validate plant payloads on client and server using a shared schema with species slug normalization and range checks
- sanitize and bound lat/lon, intervals and amounts; enforce enum fields
- ensure room IDs belong to the authenticated user before creating/updating plants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40a6f2dc0832498eef1e03ef30c84