### PR TITLE
Improve plant save error logging

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -311,9 +311,9 @@ export default function AddPlantModal({
       const context: Record<string, unknown> = { error: e };
       if (status !== undefined) context.status = status;
       if (data !== null) context.data = data;
-      console.error('Error saving plant', context);
-      setToast(message);
-      return;
+    console.error('Error saving plant', e, context);
+    setToast(message);
+    return;
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
- log original error object when plant save fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40db058448324bc7037c4b4efee62