### PR TITLE
fix: replace invalid icon import

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -24,7 +24,7 @@ import {
   AlertCircle,
   Droplet,
   FlaskRound,
-  PottedPlant,
+  Sprout,
   Home,
   X,
   Filter as FilterIcon,
@@ -619,7 +619,7 @@ export function TimelineView() {
   const typeIcons = {
     water: Droplet,
     fertilize: FlaskRound,
-    repot: PottedPlant,
+    repot: Sprout,
   } as const;
 
   const typeColors: Record<EventDTO["type"], string> = {


### PR DESCRIPTION
## Summary
- replace missing `PottedPlant` icon with `Sprout` from `lucide-react` and update mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a401491a7083249c3f61a255f2d486