### PR TITLE
refactor: use cancellable fetchJson in AddPlantModal

### DIFF
--- a/lib/fetchJson.ts
+++ b/lib/fetchJson.ts
@@ -1,0 +1,48 @@
+export interface FetchJsonError {
+  status: number;
+  data: any;
+  message: string;
+}
+
+export async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init: (RequestInit & { retries?: number }) = {},
+): Promise<T> {
+  const { retries = 0, signal: externalSignal, ...rest } = init;
+  const controller = new AbortController();
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort((externalSignal as any).reason);
+    } else {
+      externalSignal.addEventListener(
+        'abort',
+        () => controller.abort((externalSignal as any).reason),
+        { once: true },
+      );
+    }
+  }
+  let attempt = 0;
+  let delay = 500;
+  while (true) {
+    try {
+      const res = await fetch(input, { ...rest, signal: controller.signal });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw {
+          status: res.status,
+          data,
+          message:
+            (data && (data.message || data.error || data.detail)) ||
+            res.statusText,
+        } as FetchJsonError;
+      }
+      return data as T;
+    } catch (err: any) {
+      if (err?.name === 'AbortError') throw err;
+      if (attempt >= retries) throw err;
+      await new Promise((r) => setTimeout(r, delay));
+      attempt++;
+      delay *= 2;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `fetchJson` utility with abort support and structured errors
- refactor `AddPlantModal` API calls to use `fetchJson` and cancel when closed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40eefdcbc8324a18231b34de54be8