### PR TITLE
Replace PottedPlant icon with Sprout

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -24,7 +24,7 @@ import {
   AlertCircle,
   Droplet,
   FlaskRound,
-  PottedPlant,
+  Sprout,
   Home,
   X,
   Filter as FilterIcon,
@@ -619,7 +619,7 @@ export function TimelineView() {
   const typeIcons = {
     water: Droplet,
     fertilize: FlaskRound,
-    repot: PottedPlant,
+    repot: Sprout,
   } as const;
 
   const typeColors: Record<EventDTO["type"], string> = {


### PR DESCRIPTION
## Summary
- replace unavailable `PottedPlant` lucide icon with `Sprout`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40eb4a3588324934660374247250f