### PR TITLE
feat: add today local date helper

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -40,6 +40,13 @@ async function fetchWithRetry(
   }
 }
 
+export function todayLocalYYYYMMDD(): string {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
 export default function AddPlantModal({
   open,
   onOpenChange,
@@ -133,8 +140,8 @@ export default function AddPlantModal({
         waterAmount: '500',
         fertEvery: '30',
         fertFormula: stored.fertFormula || '10-10-10 @ 1/2 strength',
-        lastWatered: new Date().toISOString().slice(0, 10),
-        lastFertilized: new Date().toISOString().slice(0, 10),
+        lastWatered: todayLocalYYYYMMDD(),
+        lastFertilized: todayLocalYYYYMMDD(),
       };
       setDefaults({
         pot: base.pot,


### PR DESCRIPTION
## Summary
- add `todayLocalYYYYMMDD` helper for local YYYY-MM-DD strings
- use helper for default `lastWatered` and `lastFertilized`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser executable missing; `npx playwright install` requires additional system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a40dfe286c8324a032ab6e7a5b4ae9