### PR TITLE
Check species before defaults and debounce AI suggestions

### DIFF
--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -561,8 +561,10 @@ export function CarePlanFields({
   }, [initialSuggest, setState]);
 
   useEffect(() => {
-    async function fetchSuggest() {
-      if (!state.species) return;
+    if (!showSuggest) return;
+    if (!state.species || !state.pot) return;
+
+    const handle = setTimeout(async () => {
       setSuggestError(null);
       setLoadingSuggest(true);
       try {
@@ -607,8 +609,9 @@ export function CarePlanFields({
       } finally {
         setLoadingSuggest(false);
       }
-    }
-    if (showSuggest) fetchSuggest();
+    }, 400);
+
+    return () => clearTimeout(handle);
   }, [
     state.species,
     state.pot,


### PR DESCRIPTION
## Summary
- Trim and validate prefillName before requesting species care defaults
- Only invoke AI care when presets are absent and species & pot are set
- Debounce AI care suggestions in `CarePlanFields` by 400 ms once species and pot are provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a410507b488324b67a1a629a11656c