### PR TITLE
fix Tailwind PostCSS plugin resolution

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
 };


### PR DESCRIPTION
## Summary
- load Tailwind PostCSS and Autoprefixer via `require()` to avoid module resolution issues

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4114fb69c8324b3c51dfdcc8350db