### PR TITLE
feat: add card shadow and radius

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -462,13 +462,13 @@ export function TodayView() {
               {[...Array(2)].map((_, i) => (
                 <div
                   key={i}
-                  className="rounded-xl border bg-white shadow-sm h-16 animate-pulse"
+                  className="rounded-2xl border bg-white shadow-card h-16 animate-pulse"
                 />
               ))}
             </div>
           )}
           {!loading && err && (
-            <div className="rounded-xl border bg-white shadow-sm p-4 text-sm text-red-600">
+            <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-red-600">
               {err}
             </div>
           )}
@@ -479,7 +479,7 @@ export function TodayView() {
                 <div className="text-xs font-medium text-neutral-600 uppercase tracking-wide">
                   {plantName}
                 </div>
-                <div className="rounded-xl border bg-white shadow-sm divide-y">
+                <div className="rounded-2xl border bg-white shadow-card divide-y">
                   {items.map((t) => (
                     <TaskRow
                       key={t.id}
@@ -500,7 +500,7 @@ export function TodayView() {
               </div>
             ))}
           {!loading && !err && tasksTodayGrouped.length === 0 && (
-            <div className="rounded-xl border bg-white shadow-sm p-6 text-center text-sm text-neutral-500 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300">
+            <div className="rounded-2xl border bg-white shadow-card p-6 text-center text-sm text-neutral-500 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300">
               No tasks today — your plants are happy! 🌿
               {upcoming.length > 0 && (
                 <div className="mt-2 text-neutral-600 dark:text-neutral-300">
@@ -649,7 +649,7 @@ export function TimelineView() {
         </div>
       </header>
       <main className="flex-1 px-4 pb-28">
-        <section className="mt-4 rounded-xl border bg-white shadow-sm">
+        <section className="mt-4 rounded-2xl border bg-white shadow-card">
           <div className="px-4 py-3 border-b">
             <div className="text-base font-medium">Timeline</div>
             <div className="text-xs text-neutral-500">Recent care events</div>
@@ -785,13 +785,13 @@ export function SettingsView() {
               </Button>
             </CardContent>
           </Card>
-          <div className="rounded-xl border bg-white shadow-sm p-4 flex items-center justify-between dark:bg-neutral-800 dark:border-neutral-700">
+          <div className="rounded-2xl border bg-white shadow-card p-4 flex items-center justify-between dark:bg-neutral-800 dark:border-neutral-700">
             <div className="text-base font-medium">Theme</div>
             <ThemeToggle />
           </div>
           <button
             onClick={handleSignOut}
-            className="rounded-xl border bg-white shadow-sm p-4 text-left text-base font-medium dark:bg-neutral-800 dark:border-neutral-700"
+            className="rounded-2xl border bg-white shadow-card p-4 text-left text-base font-medium dark:bg-neutral-800 dark:border-neutral-700"
           >
             Sign out
           </button>

--- a/app/app/insights/InsightsSkeleton.tsx
+++ b/app/app/insights/InsightsSkeleton.tsx
@@ -15,14 +15,14 @@ export default function InsightsSkeleton() {
         {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-xl border bg-white shadow-sm p-4 space-y-2"
+            className="rounded-2xl border bg-white shadow-card p-4 space-y-2"
           >
             <div className="h-4 w-3/4 bg-neutral-200 rounded" />
             <div className="h-6 w-1/2 bg-neutral-200 rounded" />
           </div>
         ))}
       </div>
-      <div className="rounded-xl border bg-white shadow-sm p-4">
+      <div className="rounded-2xl border bg-white shadow-card p-4">
         <div className="h-48 bg-neutral-200 rounded" />
       </div>
     </div>

--- a/app/app/insights/InsightsView.tsx
+++ b/app/app/insights/InsightsView.tsx
@@ -92,7 +92,7 @@ export default function InsightsView() {
         <h2 className="text-sm font-display font-medium text-neutral-600">Insights</h2>
 
         {err && (
-          <div className="rounded-xl border bg-white shadow-sm p-4 text-sm text-red-600">
+          <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-red-600">
             {err}
           </div>
         )}
@@ -122,20 +122,20 @@ export default function InsightsView() {
               </label>
             </div>
             <div className="grid grid-cols-3 gap-3">
-              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
                 <div className="text-sm text-neutral-500">Completed Tasks</div>
                 <div className="text-2xl font-bold">{totalCompletedTasks}</div>
               </div>
-              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
                 <div className="text-sm text-neutral-500">Overdue Tasks</div>
                 <div className="text-2xl font-bold">{totalOverdueTasks}</div>
               </div>
-              <div className="rounded-xl border bg-white shadow-sm p-4 text-center">
+              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
                 <div className="text-sm text-neutral-500">New Plants</div>
                 <div className="text-2xl font-bold">{totalNewPlants}</div>
               </div>
             </div>
-            <div className="rounded-xl border bg-white shadow-sm p-4">
+            <div className="rounded-2xl border bg-white shadow-card p-4">
               <div className="h-48">
                 <Line
                   data={chartData}

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -34,7 +34,7 @@ export default function PlantsView() {
           </div>
 
           {err && (
-            <div className="rounded-xl border bg-white shadow-sm p-4 text-sm text-red-600">
+            <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-red-600">
               {err}
             </div>
           )}
@@ -47,7 +47,7 @@ export default function PlantsView() {
             <div className="grid grid-cols-2 gap-3">
               {sortedItems.map((p) => (
                 <Link key={p.id} href={`/app/plants/${p.id}`} className="text-left">
-                  <div className="rounded-xl border bg-white shadow-sm overflow-hidden">
+                  <div className="rounded-2xl border bg-white shadow-card overflow-hidden">
                     <div className="h-24 bg-neutral-100" />
                     <div className="p-2">
                       <div className="text-sm font-medium truncate">{p.name}</div>

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -279,7 +279,7 @@ export default function PlantDetailClient({ plant }: { plant: {
       {/* Content */}
       <main className="flex-1 px-4 pb-28">
         {/* Hero */}
-        <div className="rounded-2xl overflow-hidden border bg-white shadow-sm mt-4">
+        <div className="rounded-2xl overflow-hidden border bg-white shadow-card mt-4">
         <img src={heroPhoto} alt={name} className="h-40 w-full object-cover bg-neutral-200" />
           <div className="p-4">
             <h2 className="text-lg font-display font-semibold">{name}</h2>
@@ -368,7 +368,7 @@ export default function PlantDetailClient({ plant }: { plant: {
         )}
 
         {tab === "timeline" && (
-          <section className="mt-4 rounded-xl border bg-white shadow-sm">
+          <section className="mt-4 rounded-2xl border bg-white shadow-card">
             <div className="px-4 py-3 border-b">
               <div className="text-base font-medium">Timeline</div>
               <div className="text-xs text-neutral-500">Upcoming &amp; recent care</div>
@@ -400,7 +400,7 @@ export default function PlantDetailClient({ plant }: { plant: {
         )}
 
         {tab === "notes" && (
-          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4 text-sm">
+          <section className="mt-4 rounded-2xl border bg-white shadow-card p-4 text-sm">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -434,7 +434,7 @@ export default function PlantDetailClient({ plant }: { plant: {
         )}
 
         {tab === "photos" && (
-          <section className="mt-4 rounded-xl border bg-white shadow-sm p-4">
+          <section className="mt-4 rounded-2xl border bg-white shadow-card p-4">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -511,7 +511,7 @@ export default function PlantDetailClient({ plant }: { plant: {
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-xl border bg-white p-3 shadow-sm">
+    <div className="rounded-2xl border bg-white p-3 shadow-card">
       <div className="text-xs text-neutral-500">{label}</div>
       <div className="text-base font-medium">{value}</div>
     </div>

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -327,7 +327,7 @@ export default function AddPlantModal({
       >
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
         <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
-          <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-md sm:max-h-[90vh] flex flex-col">
+          <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-card sm:max-h-[90vh] flex flex-col">
             <header className="sticky top-0 bg-background border-b p-6">
               <Dialog.Title
                 id={titleId}

--- a/components/CareSummary.tsx
+++ b/components/CareSummary.tsx
@@ -26,7 +26,7 @@ export default function CareSummary({
 
   return (
     <div className="mt-4 grid grid-cols-2 gap-3">
-      <div className="flex items-center gap-2 rounded-xl border bg-white p-3 shadow-sm">
+      <div className="flex items-center gap-2 rounded-2xl border bg-white p-3 shadow-card">
         <Droplet className="h-4 w-4" />
         <div>
           <div className="text-xs text-neutral-500">Water</div>
@@ -39,7 +39,7 @@ export default function CareSummary({
           </div>
         </div>
       </div>
-      <div className="flex items-center gap-2 rounded-xl border bg-white p-3 shadow-sm">
+      <div className="flex items-center gap-2 rounded-2xl border bg-white p-3 shadow-card">
         <FlaskConical className="h-4 w-4" />
         <div>
           <div className="text-xs text-neutral-500">Fertilize</div>

--- a/components/EditPlantModal.tsx
+++ b/components/EditPlantModal.tsx
@@ -37,7 +37,7 @@ export default function EditPlantModal({
     <Dialog open={open} onClose={close} className="relative z-50">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex items-end sm:items-center justify-center p-4">
-        <Dialog.Panel className="relative w-full sm:max-w-lg bg-white rounded-t-2xl sm:rounded-2xl shadow-xl max-h-[90vh] overflow-y-auto">
+        <Dialog.Panel className="relative w-full sm:max-w-lg bg-white rounded-t-2xl sm:rounded-2xl shadow-card max-h-[90vh] overflow-y-auto">
           <div className="p-5 border-b">
             <Dialog.Title className="text-lg font-display font-semibold">Edit Plant</Dialog.Title>
           </div>

--- a/components/FiltersModal.tsx
+++ b/components/FiltersModal.tsx
@@ -40,7 +40,7 @@ export default function FiltersModal({
     <Dialog open={open} onClose={onClose} className="relative z-50">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex items-end sm:items-center justify-center p-4">
-        <Dialog.Panel className="relative w-full sm:max-w-sm bg-white rounded-t-2xl sm:rounded-2xl p-4 shadow-xl max-h-[90vh] overflow-y-auto">
+        <Dialog.Panel className="relative w-full sm:max-w-sm bg-white rounded-t-2xl sm:rounded-2xl p-4 shadow-card max-h-[90vh] overflow-y-auto">
           <div className="mb-3">
             <Dialog.Title className="text-lg font-semibold">Filters</Dialog.Title>
           </div>

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -653,7 +653,7 @@ export function CarePlanFields({
   return (
     <div className="p-6 space-y-6">
       {showSuggest && (
-        <div className="rounded-xl border p-3 bg-neutral-50">
+        <div className="rounded-2xl border p-3 bg-neutral-50">
           <div className="text-sm font-medium mb-2">
             AI-generated plan — Review and customize before saving.
           </div>

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -64,7 +64,7 @@ export default function TaskRow({
       aria-label={`Task for ${plant}: ${action}. Last ${last}. Due ${due}. Press Enter or O to open, C to complete, S to snooze.`}
     >
       <div className="sr-only" aria-live="polite">{announce}</div>
-      <div className="absolute inset-0 rounded-xl overflow-hidden">
+      <div className="absolute inset-0 rounded-2xl overflow-hidden">
         <div className="absolute inset-y-0 left-0 w-20 grid place-items-center bg-emerald-100 text-emerald-700">
           <div className="flex items-center gap-2 text-xs font-medium">
             <Check className="h-4 w-4" />
@@ -88,7 +88,7 @@ export default function TaskRow({
         }}
         className="relative"
       >
-        <div className="rounded-xl border bg-white shadow-sm dark:bg-neutral-800 dark:border-neutral-700">
+        <div className="rounded-2xl border bg-white shadow-card dark:bg-neutral-800 dark:border-neutral-700">
           <div className="p-3 flex items-center gap-3">
             <button
               onClick={onOpen}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,7 +8,7 @@ type PProps = React.HTMLAttributes<HTMLParagraphElement>;
 export function Card({ className = "", ...props }: DivProps) {
   return (
     <div
-      className={`rounded-xl border bg-white shadow-md dark:bg-neutral-800 dark:border-neutral-700 ${className}`}
+      className={`rounded-2xl border bg-white shadow-card dark:bg-neutral-800 dark:border-neutral-700 ${className}`}
       {...props}
     />
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -48,7 +48,7 @@ export function DialogContent({
       <div
         role="dialog"
         aria-modal="true"
-        className={`relative z-50 w-[min(560px,92vw)] mx-4 rounded-2xl bg-white shadow-xl ${className}`}
+        className={`relative z-50 w-[min(560px,92vw)] mx-4 rounded-2xl bg-white shadow-card ${className}`}
       >
         {children}
       </div>

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -35,7 +35,7 @@ Use varied sizes for hierarchy:
 - Use grid layouts for dashboards and plant galleries.
 - Consistent padding: `p-4`, `p-6` for sections.
 - Rounded corners: `rounded-2xl`
-- Soft drop shadows: `shadow-md`
+- Soft drop shadows: `shadow-card`
 
 ---
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,14 @@ export default {
         },
         muted: "hsl(var(--muted))",
       },
+      borderRadius: {
+        lg: "14px",
+        xl: "18px",
+        "2xl": "22px",
+      },
+      boxShadow: {
+        card: "0 1px 2px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.06)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- extend Tailwind theme with larger radius sizes and `shadow-card`
- update modals and card components to use `rounded-2xl shadow-card`
- document new shadow token in style guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a41361a5b08324887e2bac9a0b920c