### PR TITLE
Add dialog keyboard navigation and typed environment enums

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -3,6 +3,7 @@ import { listPlants, createPlant } from "@/lib/prisma/plants";
 import { createRouteHandlerClient } from "@/lib/supabase";
 import { getUserId } from "@/lib/getUserId";
 import { z } from "zod";
+import { drainageEnum } from "@/lib/plantFormSchema";
 
 const missingEnv = () =>
   !process.env.DATABASE_URL ||
@@ -68,7 +69,7 @@ export async function POST(req: NextRequest) {
       soilType: z.string().optional(),
       lightLevel: z.string().optional(),
       indoor: z.coerce.boolean().optional(),
-      drainage: z.enum(["poor", "ok", "great"]).optional(),
+      drainage: drainageEnum.optional(),
       lat: z.coerce.number().optional(),
       lon: z.coerce.number().optional(),
       carePlanSource: z.string().optional(),

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Droplet, FlaskConical, Sprout, Pencil } from "lucide-react";
 import EditPlantModal from '@/components/EditPlantModal';
 import BottomNav from '@/components/BottomNav';
 import CareSummary from '@/components/CareSummary';
+import type { DrainageOption } from '@/lib/plantFormSchema';
 
 type CareType = "water" | "fertilize" | "repot";
 type TaskDTO = {
@@ -40,7 +41,7 @@ export default function PlantDetailClient({ plant }: { plant: {
   potSize?: string;
   potMaterial?: string;
   soilType?: string;
-  drainage?: 'poor' | 'ok' | 'great';
+  drainage?: DrainageOption;
   indoor?: boolean;
   latitude?: number;
   longitude?: number;

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -13,7 +13,14 @@ import {
   plantValuesToSubmit,
   PlanSource,
 } from './PlantForm';
-import { plantFormSchema, plantFieldSchemas } from '@/lib/plantFormSchema';
+import {
+  plantFormSchema,
+  plantFieldSchemas,
+  indoorEnum,
+  drainageEnum,
+  type IndoorOption,
+  type DrainageOption,
+} from '@/lib/plantFormSchema';
 import type { AiCareSuggestion } from '@/lib/aiCare';
 import { fetchJson } from '@/lib/fetchJson';
 
@@ -28,13 +35,13 @@ export default function AddPlantModal({
   open,
   onOpenChange,
   prefillName,
-  defaultRoomId,
+  defaultRoomId = '',
   onCreate,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
   prefillName?: string;
-  defaultRoomId: string;
+  defaultRoomId?: string;
   onCreate: (plant: { id: string; name: string }) => void;
 }) {
   const titleId = useId();
@@ -130,8 +137,8 @@ export default function AddPlantModal({
         pot: stored.pot || '6 in',
         potMaterial: stored.potMaterial || 'Plastic',
         light: stored.light || 'Medium',
-        indoor: 'Indoor',
-        drainage: 'ok',
+        indoor: indoorEnum.options[0] as IndoorOption,
+        drainage: drainageEnum.options[1] as DrainageOption,
         soil: stored.soil || 'Well-draining mix',
         humidity: stored.humidity || '50',
         lat: '',
@@ -314,6 +321,20 @@ export default function AddPlantModal({
     setStep((s) => Math.max(s - 1, 0));
   }
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.target instanceof HTMLTextAreaElement) return;
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    if (e.shiftKey) {
+      prevStep();
+    } else if (step < 2) {
+      if (step === 0 && !basicsValid) return;
+      nextStep();
+    } else if (!saving && canSubmit) {
+      submitCurrent(planSource?.type === 'ai' ? 'ai' : 'manual');
+    }
+  }
+
   if (!open) return null;
 
   return (
@@ -327,7 +348,10 @@ export default function AddPlantModal({
       >
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
         <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
-          <Dialog.Panel className="relative w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-md sm:max-h-[90vh] flex flex-col">
+          <Dialog.Panel
+            className="relative w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-md sm:max-h-[90vh] flex flex-col"
+            onKeyDown={handleKeyDown}
+          >
             <header className="sticky top-0 bg-background border-b p-6">
               <Dialog.Title
                 id={titleId}

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -4,7 +4,14 @@ import React, { useEffect, useState } from 'react';
 
 import type { AiCareSuggestion } from '@/lib/aiCare';
 import { z } from 'zod';
-import { plantFieldSchemas, plantFormSchema } from '@/lib/plantFormSchema';
+import {
+  plantFieldSchemas,
+  plantFormSchema,
+  indoorEnum,
+  drainageEnum,
+  type IndoorOption,
+  type DrainageOption,
+} from '@/lib/plantFormSchema';
 
 
 import SpeciesAutosuggest from './SpeciesAutosuggest';
@@ -20,8 +27,8 @@ export type PlantFormValues = {
   pot: string;
   potMaterial: string;
   light: string;
-  indoor: 'Indoor' | 'Outdoor';
-  drainage: 'poor' | 'ok' | 'great';
+  indoor: IndoorOption;
+  drainage: DrainageOption;
   soil: string;
   humidity: string;
   lat?: string;
@@ -43,7 +50,7 @@ export type PlantFormSubmit = {
   lightLevel: string;
   indoor: boolean;
   soilType?: string;
-  drainage: 'poor' | 'ok' | 'great';
+  drainage: DrainageOption;
   lat?: number;
   lon?: number;
   lastWateredAt?: string;
@@ -106,6 +113,8 @@ type SectionProps = {
 type FieldName =
   | 'name'
   | 'roomId'
+  | 'indoor'
+  | 'drainage'
   | 'waterEvery'
   | 'waterAmount'
   | 'fertEvery'
@@ -360,22 +369,29 @@ export function EnvironmentFields({
             className="input"
             value={state.indoor}
             onChange={(e) =>
-              setState({ ...state, indoor: e.target.value as 'Indoor' | 'Outdoor' })
+              setState({ ...state, indoor: e.target.value as IndoorOption })
             }
           >
-            <option>Indoor</option>
-            <option>Outdoor</option>
+            {indoorEnum.options.map((o) => (
+              <option key={o}>{o}</option>
+            ))}
           </select>
           <select
             className="input"
             value={state.drainage}
             onChange={(e) =>
-              setState({ ...state, drainage: e.target.value as 'poor' | 'ok' | 'great' })
+              setState({ ...state, drainage: e.target.value as DrainageOption })
             }
           >
-            <option value="poor">Poor drainage</option>
-            <option value="ok">OK drainage</option>
-            <option value="great">Great drainage</option>
+            {drainageEnum.options.map((o) => (
+              <option key={o} value={o}>
+                {o === 'poor'
+                  ? 'Poor drainage'
+                  : o === 'ok'
+                  ? 'OK drainage'
+                  : 'Great drainage'}
+              </option>
+            ))}
           </select>
         </div>
       </Field>

--- a/lib/aiCare.ts
+++ b/lib/aiCare.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import type { DrainageOption } from './plantFormSchema';
 
 export type AiCareParams = {
   name?: string;
@@ -7,7 +8,7 @@ export type AiCareParams = {
   potMaterial?: string;
   light?: string;
   indoor?: boolean;
-  drainage?: string;
+  drainage?: DrainageOption;
   soil?: string;
   humidity?: number;
   lat?: number;
@@ -30,7 +31,7 @@ export async function suggestCare({
   potMaterial = '',
   light = '',
   indoor,
-  drainage = '',
+  drainage,
   soil = '',
   humidity,
   lat,

--- a/lib/plantFormSchema.test.ts
+++ b/lib/plantFormSchema.test.ts
@@ -5,6 +5,8 @@ describe('plantFormSchema', () => {
     const res = plantFormSchema.safeParse({
       name: '',
       roomId: '',
+      indoor: 'Indoor',
+      drainage: 'ok',
       waterEvery: '1',
       waterAmount: '10',
       fertEvery: '1',
@@ -21,6 +23,8 @@ describe('plantFormSchema', () => {
     const res = plantFormSchema.safeParse({
       name: 'A',
       roomId: 'r1',
+      indoor: 'Indoor',
+      drainage: 'ok',
       waterEvery: '0',
       waterAmount: '9',
       fertEvery: '0',
@@ -38,6 +42,8 @@ describe('plantFormSchema', () => {
     const res = plantFormSchema.safeParse({
       name: 'A',
       roomId: 'r1',
+      indoor: 'Indoor',
+      drainage: 'ok',
       waterEvery: '1',
       waterAmount: '10',
       fertEvery: '1',

--- a/lib/plantFormSchema.ts
+++ b/lib/plantFormSchema.ts
@@ -1,8 +1,16 @@
 import { z } from 'zod';
 
+export const indoorEnum = z.enum(['Indoor', 'Outdoor']);
+export type IndoorOption = z.infer<typeof indoorEnum>;
+
+export const drainageEnum = z.enum(['poor', 'ok', 'great']);
+export type DrainageOption = z.infer<typeof drainageEnum>;
+
 export const plantFieldSchemas = {
   name: z.string().trim().min(1, 'Enter a plant name.'),
   roomId: z.string().min(1, 'Choose a room or add one.'),
+  indoor: indoorEnum,
+  drainage: drainageEnum,
   waterEvery: z.coerce.number().min(1, 'Must be at least 1 day'),
   waterAmount: z.coerce.number().min(10, 'Must be at least 10 ml'),
   fertEvery: z.coerce.number().min(1, 'Must be at least 1 day'),

--- a/lib/prisma/plants.ts
+++ b/lib/prisma/plants.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, Plant, Prisma } from "@prisma/client";
+import type { DrainageOption } from "@/lib/plantFormSchema";
 
 const prisma = new PrismaClient();
 
@@ -11,7 +12,7 @@ type PlantData = {
   soilType?: string | null;
   lightLevel?: string | null;
   indoor?: boolean | null;
-  drainage?: 'poor' | 'ok' | 'great' | null;
+  drainage?: DrainageOption | null;
   lat?: number | null;
   lon?: number | null;
   carePlanSource?: string | null;

--- a/lib/species-care.ts
+++ b/lib/species-care.ts
@@ -6,12 +6,14 @@
  * `SpeciesCareDefaults` type must be provided so that lookups remain
  * consistent.
  */
+import type { IndoorOption, DrainageOption } from './plantFormSchema';
+
 export type SpeciesCareDefaults = {
   pot: string;
   potMaterial: string;
   light: string;
-  indoor: 'Indoor' | 'Outdoor';
-  drainage: 'poor' | 'ok' | 'great';
+  indoor: IndoorOption;
+  drainage: DrainageOption;
   soil: string;
   waterEvery: string;
   waterAmount: string;


### PR DESCRIPTION
## Summary
- Navigate add-plant dialog with Enter/Shift+Enter and default `defaultRoomId` to an empty string
- Define enums for indoor/outdoor and drainage options and apply them across the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4136a5aec8324bdd416c418296326