### PR TITLE
chore: guard debug log in AddPlantModal

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -229,7 +229,9 @@ export default function AddPlantModal({
     data: PlantFormSubmit,
     source: 'ai' | 'manual' = 'manual',
   ) {
-    console.log('Creating plant via', source, 'plan source', planSource);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Creating plant via', source, 'plan source', planSource);
+    }
     const payload: any = { ...data };
     if (!requestIdRef.current) {
       requestIdRef.current = crypto.randomUUID();


### PR DESCRIPTION
## Summary
- guard console output in AddPlantModal so it only runs in non-production env

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a415656278832483c48ce303ee7997