### PR TITLE
refactor: type EditPlantModal with Prisma Plant

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Droplet, FlaskConical, Sprout, Pencil } from "lucide-react";
 import EditPlantModal from '@/components/EditPlantModal';
 import BottomNav from '@/components/BottomNav';
 import CareSummary from '@/components/CareSummary';
+import type { Plant } from '@prisma/client';
 
 type CareType = "water" | "fertilize" | "repot";
 type TaskDTO = {
@@ -21,11 +22,7 @@ type TaskDTO = {
 
 type Note = { id: string; note: string; createdAt: string };
 
-export default function PlantDetailClient({ plant }: { plant: {
-  id: string;
-  name: string;
-  species?: string;
-  roomId?: string;
+type PlantExtras = {
   photos?: string[];
   acquiredAt?: string;
   nextWater?: string;
@@ -35,17 +32,11 @@ export default function PlantDetailClient({ plant }: { plant: {
   fertilizeIntervalDays?: number;
   fertilizeFormula?: string;
   light?: string;
-  lightLevel?: string;
   humidity?: string;
-  potSize?: string;
-  potMaterial?: string;
-  soilType?: string;
-  drainage?: 'poor' | 'ok' | 'great';
-  indoor?: boolean;
-  latitude?: number;
-  longitude?: number;
-} }) {
-  const [plantState, setPlantState] = useState(plant);
+};
+
+export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtras }) {
+  const [plantState, setPlantState] = useState<Plant & PlantExtras>(plant);
   const id = plantState.id;
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/components/EditPlantModal.tsx
+++ b/components/EditPlantModal.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Dialog } from '@headlessui/react';
 import PlantForm, { PlantFormSubmit } from './PlantForm';
+import type { Plant } from '@prisma/client';
 
 export default function EditPlantModal({
   open,
@@ -12,8 +13,8 @@ export default function EditPlantModal({
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
-  plant: any;
-  onUpdated: (p: any) => void;
+  plant: Plant;
+  onUpdated: (p: Plant) => void;
 }) {
   function close() {
     onOpenChange(false);


### PR DESCRIPTION
## Summary
- type EditPlantModal props with `Plant`
- propagate `Plant` typing to PlantDetailClient

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4154b6dc08324b5e652ec56335ad4