### PR TITLE
Use Prisma singleton across app

### DIFF
--- a/lib/prisma/client.ts
+++ b/lib/prisma/client.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = globalThis.prisma ??= new PrismaClient();
+
+export default prisma;

--- a/lib/prisma/plants.ts
+++ b/lib/prisma/plants.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Plant, Prisma } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { Plant, Prisma } from "@prisma/client";
+import { prisma } from "./client";
 
 type PlantData = {
   name?: string;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "../lib/prisma/client";
 
 async function main() {
   // Clear tables but no longer seed mock data.


### PR DESCRIPTION
## Summary
- introduce global Prisma client to share a single connection
- switch modules to import the shared Prisma instance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4155c28b883249447770e637262f7