### PR TITLE
refactor: rely on Supabase client env validation

### DIFF
--- a/app/api/plants/route.test.ts
+++ b/app/api/plants/route.test.ts
@@ -223,19 +223,6 @@ describe('GET/POST /api/plants', () => {
     ]);
   });
 
-  it('returns 503 when env vars missing', async () => {
-    delete process.env.DATABASE_URL;
-    const res = await GET();
-    expect(res.status).toBe(503);
-    const json = await res.json();
-    expect(json).toEqual({
-      error: 'misconfigured server',
-      message:
-        'Set NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, and DATABASE_URL, or enable SINGLE_USER_MODE',
-    });
-    expect(listPlants).not.toHaveBeenCalled();
-  });
-
   it('returns 500 when SINGLE_USER_ID missing in single-user mode', async () => {
     process.env.SINGLE_USER_MODE = 'true';
     delete process.env.SINGLE_USER_ID;

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -4,28 +4,8 @@ import { createRouteHandlerClient } from "@/lib/supabase";
 import { getUserId } from "@/lib/getUserId";
 import { z } from "zod";
 
-const missingEnv = () =>
-  !process.env.DATABASE_URL ||
-  !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-const envErrorResponse = () =>
-  NextResponse.json(
-    {
-      error: "misconfigured server",
-      message:
-        "Set NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, and DATABASE_URL, or enable SINGLE_USER_MODE",
-    },
-    { status: 503 }
-  );
-
 export async function GET() {
   try {
-    if (missingEnv()) {
-      console.error("Missing Supabase or database environment variables");
-      return envErrorResponse();
-    }
-
     const plants = await listPlants();
     return NextResponse.json(plants);
   } catch (e: any) {
@@ -36,11 +16,6 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    if (missingEnv()) {
-      console.error("Missing Supabase or database environment variables");
-      return envErrorResponse();
-    }
-
     const supabase = await createRouteHandlerClient();
     const userRes = await getUserId(supabase);
     if ("error" in userRes) {

--- a/app/api/rooms/route.test.ts
+++ b/app/api/rooms/route.test.ts
@@ -61,15 +61,6 @@ describe('GET/POST /api/rooms', () => {
     expect(mockFrom).toHaveBeenCalledWith('rooms');
   });
 
-  it('returns 500 when env vars missing', async () => {
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const res = await GET();
-    expect(res.status).toBe(500);
-    const json = await res.json();
-    expect(json).toEqual({ error: 'misconfigured server' });
-    expect(createRouteHandlerClient).not.toHaveBeenCalled();
-  });
-
   it('returns 500 when SINGLE_USER_ID missing in single-user mode', async () => {
     process.env.SINGLE_USER_MODE = 'true';
     delete process.env.SINGLE_USER_ID;

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -4,14 +4,6 @@ import { getUserId } from "@/lib/getUserId";
 
 export async function GET() {
   try {
-    if (
-      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    ) {
-      console.error("Missing Supabase environment variables");
-      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
-    }
-
     const supabase = await createRouteHandlerClient();
     const userRes = await getUserId(supabase);
     if ("error" in userRes) {
@@ -39,14 +31,6 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    if (
-      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    ) {
-      console.error("Missing Supabase environment variables");
-      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
-    }
-
     const supabase = await createRouteHandlerClient();
     const userRes = await getUserId(supabase);
     if ("error" in userRes) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./supabase.types";
 
-function getSupabaseEnv() {
+export function ensureSupabaseEnv() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !anonKey) {
@@ -12,14 +12,14 @@ function getSupabaseEnv() {
 
 // Factory for an unauthenticated client
 export function createSupabaseClient(): SupabaseClient<Database> {
-  const { url, anonKey } = getSupabaseEnv();
+  const { url, anonKey } = ensureSupabaseEnv();
   return createClient<Database>(url, anonKey);
 }
 
 // Authenticated client helper for Route Handlers
 export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
   const { cookies } = await import("next/headers");
-  const { url, anonKey } = getSupabaseEnv();
+  const { url, anonKey } = ensureSupabaseEnv();
   // `cookies()` is now asynchronous in Next 15 and must be awaited
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("sb-access-token")?.value;

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,10 +1,11 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./supabase.types";
+import { ensureSupabaseEnv } from "./supabase";
 
 export function createSupabaseAdminClient(): SupabaseClient<Database> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const { url } = ensureSupabaseEnv();
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceKey) {
+  if (!serviceKey) {
     throw new Error("Missing Supabase environment variables");
   }
   return createClient<Database>(url, serviceKey, {


### PR DESCRIPTION
## Summary
- remove manual Supabase env checks from room and plant API routes
- export ensureSupabaseEnv helper and use it for admin client
- update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4154a68a083248830f390957a337d