### PR TITLE
Add last done tracking and fix Tailwind color usage

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -40,7 +40,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
       }
       const { error } = await supabase
         .from("tasks")
-        .update({ due_at: task.dueAt })
+        .update({ due_at: task.dueAt, last_done_at: null })
         .eq("id", taskId ?? task.id)
         .eq("user_id", userId);
       if (error) {
@@ -54,7 +54,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
       ? await supabase
           .from("tasks")
           .select(
-            "id, plant_id, type, due_at, plant:plants(id, name, room_id)",
+            "id, plant_id, type, due_at, last_done_at, plant:plants(id, name, room_id)",
           )
           .eq("user_id", userId)
           .eq("id", taskId)
@@ -62,7 +62,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
       : await supabase
           .from("tasks")
           .select(
-            "id, plant_id, type, due_at, plant:plants(id, name, room_id)",
+            "id, plant_id, type, due_at, last_done_at, plant:plants(id, name, room_id)",
           )
           .eq("user_id", userId)
           .eq("plant_id", plantId as string)
@@ -79,7 +79,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
         .from("tasks")
         .update({ due_at: d.toISOString() })
         .eq("id", existing.id)
-        .select("id, type, due_at, plant:plants(id, name, room_id)")
+        .select("id, type, due_at, last_done_at, plant:plants(id, name, room_id)")
         .single();
       if (error) {
         console.error("PATCH /api/tasks/[id] defer failed:", error);
@@ -93,7 +93,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
         type: data.type,
         dueAt: data.due_at,
         status: "due" as const,
-        lastEventAt: null,
+        lastEventAt: data.last_done_at || null,
       };
       return NextResponse.json(rec);
     }
@@ -104,7 +104,7 @@ export async function PATCH(req: NextRequest, ctx: any) {
       d.setDate(d.getDate() + 1);
       const { error } = await supabase
         .from("tasks")
-        .update({ due_at: d.toISOString() })
+        .update({ due_at: d.toISOString(), last_done_at: eventAt })
         .eq("id", existing.id);
       if (error) {
         console.error("PATCH /api/tasks/[id] complete failed:", error);

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("tasks")
-    .select("id, type, due_at, plant:plants(id, name, room_id)")
+    .select("id, type, due_at, last_done_at, plant:plants(id, name, room_id)")
     .eq("user_id", userId)
     .lte("due_at", maxDate.toISOString())
     .order("due_at");
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
     type: t.type,
     dueAt: t.due_at,
     status: "due",
-    lastEventAt: null,
+    lastEventAt: t.last_done_at || null,
   }));
 
   return NextResponse.json(tasks);
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest) {
       type,
       due_at: dueAt,
     })
-    .select("id, type, due_at, plant:plants(id, name, room_id)")
+    .select("id, type, due_at, last_done_at, plant:plants(id, name, room_id)")
     .single();
   if (error) {
     console.error("POST /api/tasks failed:", error);
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
     type: data.type,
     dueAt: data.due_at,
     status: "due",
-    lastEventAt: null,
+    lastEventAt: data.last_done_at || null,
   };
   return NextResponse.json(rec, { status: 201 });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,8 @@
     --muted: 218 11% 65%;
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }
 

--- a/prisma/migrations/20250822000000_tasks_last_done_at/migration.sql
+++ b/prisma/migrations/20250822000000_tasks_last_done_at/migration.sql
@@ -1,0 +1,2 @@
+-- Add last_done_at column to tasks table
+ALTER TABLE "public"."tasks" ADD COLUMN IF NOT EXISTS "last_done_at" TIMESTAMP(3);

--- a/supabase/migrations/0008_tasks_last_done_at.sql
+++ b/supabase/migrations/0008_tasks_last_done_at.sql
@@ -1,0 +1,2 @@
+-- Add last_done_at column to tasks
+alter table public.tasks add column if not exists last_done_at timestamptz;


### PR DESCRIPTION
## Summary
- track last completion time for tasks and expose it via API
- add database migrations for tasks.last_done_at
- use CSS variables directly in globals to fix Tailwind build error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4162eded083248ccbd696c915ea7f