### PR TITLE
Enable Supabase User relations in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Plant {
   lastFertilizedAt DateTime? @map("last_fertilized_at")
   createdAt   DateTime @default(now()) @map("created_at")
 
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   tasks  Task[]
   photos PlantPhoto[]
 
@@ -42,6 +43,8 @@ model Room {
   id     String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId String @map("user_id") @db.Uuid
   name   String
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("rooms")
   @@schema("public")
@@ -57,6 +60,7 @@ model Task {
   notes      String?
   createdAt  DateTime  @default(now()) @map("created_at")
 
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
   plant Plant @relation(fields: [plantId], references: [id], onDelete: Cascade)
 
   @@map("tasks")
@@ -70,6 +74,7 @@ model PlantPhoto {
   url       String
   createdAt DateTime @default(now()) @map("created_at")
 
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
   plant Plant @relation(fields: [plantId], references: [id], onDelete: Cascade)
 
   @@map("plant_photos")
@@ -77,9 +82,12 @@ model PlantPhoto {
 }
 
 model User {
-  id String @id @db.Uuid
+  id     String      @id @db.Uuid
+  plants Plant[]
+  rooms  Room[]
+  tasks  Task[]
+  photos PlantPhoto[]
 
   @@map("users")
   @@schema("auth")
-  @@ignore
 }


### PR DESCRIPTION
## Summary
- connect Plant, Room, Task, and PlantPhoto models to Supabase auth.users
- expose the auth.users table to Prisma client

## Testing
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68a41844d5bc832484141cd57ecfb633