### PR TITLE
Use service role key in single-user mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Useful when running locally without authentication.
 ```
 SINGLE_USER_MODE=true
 SINGLE_USER_ID=<supabase user uuid>
+# requires SUPABASE_SERVICE_ROLE_KEY for database access
 ```
 Restart the dev server after changing these values.
 


### PR DESCRIPTION
## Summary
- support Supabase service role key when `SINGLE_USER_MODE` is enabled so API routes work without a user session
- document the service role key requirement in single-user mode instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46aa756b083248367dee684a2b1ea