### PR TITLE
feat: add border color theme

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -244,7 +244,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
   return (
     <div className="min-h-[100dvh] bg-neutral-50 text-neutral-900 flex flex-col">
       {/* Header */}
-      <header className="px-4 pt-6 pb-2 sticky top-0 bg-white/90 backdrop-blur border-b">
+      <header className="px-4 pt-6 pb-2 sticky top-0 bg-white/90 backdrop-blur border-b border-border">
         <div className="flex items-center gap-2">
           <Link href="/app" aria-label="Back" className="h-9 w-9 rounded-lg grid place-items-center hover:bg-neutral-100">
             <ArrowLeft className="h-5 w-5" />
@@ -270,7 +270,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
       {/* Content */}
       <main className="flex-1 px-4 pb-28">
         {/* Hero */}
-        <div className="rounded-2xl overflow-hidden border bg-white shadow-card mt-4">
+        <div className="rounded-2xl overflow-hidden border border-border bg-white shadow-card mt-4">
         <img src={heroPhoto} alt={name} className="h-40 w-full object-cover bg-neutral-200" />
           <div className="p-4">
             <h2 className="text-lg font-display font-semibold">{name}</h2>
@@ -298,25 +298,25 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
           {/* Tabs */}
           <div className="mt-4 grid grid-cols-4 gap-2 text-sm">
           <button
-            className={`py-2 rounded-lg border ${tab === "stats" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
+            className={`py-2 rounded-lg border border-border ${tab === "stats" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
             onClick={() => setTab("stats")}
           >
             Stats
           </button>
           <button
-            className={`py-2 rounded-lg border ${tab === "timeline" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
+            className={`py-2 rounded-lg border border-border ${tab === "timeline" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
             onClick={() => setTab("timeline")}
           >
             Timeline
           </button>
           <button
-            className={`py-2 rounded-lg border ${tab === "notes" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
+            className={`py-2 rounded-lg border border-border ${tab === "notes" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
             onClick={() => setTab("notes")}
           >
             Notes
           </button>
           <button
-            className={`py-2 rounded-lg border ${tab === "photos" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
+            className={`py-2 rounded-lg border border-border ${tab === "photos" ? "bg-white shadow-sm font-medium" : "text-neutral-600"}`}
             onClick={() => setTab("photos")}
           >
             Photos
@@ -359,8 +359,8 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
         )}
 
         {tab === "timeline" && (
-          <section className="mt-4 rounded-2xl border bg-white shadow-card">
-            <div className="px-4 py-3 border-b">
+          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card">
+            <div className="px-4 py-3 border-b border-border">
               <div className="text-base font-medium">Timeline</div>
               <div className="text-xs text-neutral-500">Upcoming &amp; recent care</div>
             </div>
@@ -374,7 +374,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
               {err && <li className="py-3 text-red-600">{err}</li>}
               {!err && plantTasks.length === 0 && <li className="py-3 text-neutral-500">No tasks yet</li>}
               {!err && plantTasks.map(t => (
-                <li key={t.id} className="py-3 border-b last:border-b-0 flex justify-between items-center">
+                <li key={t.id} className="py-3 border-b border-border last:border-b-0 flex justify-between items-center">
                   <span>
                     {iconFor(t.type)} {t.type === "water" ? "Water" : t.type === "fertilize" ? "Fertilize" : "Repot"} — {new Intl.DateTimeFormat(undefined, { month:"short", day:"numeric" }).format(new Date(t.dueAt))}
                     {(() => {
@@ -391,7 +391,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
         )}
 
         {tab === "notes" && (
-          <section className="mt-4 rounded-2xl border bg-white shadow-card p-4 text-sm">
+          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card p-4 text-sm">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -402,7 +402,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
                 value={noteText}
                 onChange={(e) => setNoteText(e.target.value)}
                 placeholder="Write a note..."
-                className="w-full border rounded p-2 text-sm"
+                className="w-full border border-border rounded p-2 text-sm"
               />
               <div className="text-right mt-2">
                 <button type="submit" className="px-3 py-1 rounded bg-neutral-900 text-white text-xs">
@@ -413,7 +413,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
             <ul className="mt-4 space-y-3">
               {notes.length === 0 && <li className="text-neutral-500">No notes yet</li>}
               {notes.map((n) => (
-                <li key={n.id} className="border-t pt-2 first:border-t-0 first:pt-0">
+                <li key={n.id} className="border-t border-border pt-2 first:border-t-0 first:pt-0">
                   <div>{n.note}</div>
                   <div className="text-xs text-neutral-500">
                     {new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(new Date(n.createdAt))}
@@ -425,7 +425,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
         )}
 
         {tab === "photos" && (
-          <section className="mt-4 rounded-2xl border bg-white shadow-card p-4">
+          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card p-4">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -439,7 +439,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
                 accept="image/*"
                 capture="environment"
                 onChange={(e) => setNewPhotoFile(e.target.files?.[0] || null)}
-                className="flex-1 border rounded p-2 text-sm"
+                className="flex-1 border border-border rounded p-2 text-sm"
               />
               <button
                 type="submit"
@@ -502,7 +502,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border bg-white p-3 shadow-card">
+    <div className="rounded-2xl border border-border bg-white p-3 shadow-card">
       <div className="text-xs text-neutral-500">{label}</div>
       <div className="text-base font-medium">{value}</div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,7 @@
     --secondary: 164 42% 88%;
     --secondary-foreground: 221 39% 11%;
     --muted: 218 11% 65%;
+    --border: 221 14% 90%;
   }
   .dark {
     --background: 221 39% 11%;
@@ -18,6 +19,7 @@
     --secondary: 164 42% 20%;
     --secondary-foreground: 0 0% 98%;
     --muted: 218 11% 65%;
+    --border: 221 14% 30%;
   }
   body {
     background-color: hsl(var(--background));

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -43,7 +43,7 @@ export default function BottomNav({ value }: { value: Tab }) {
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t dark:bg-neutral-900/90 dark:border-neutral-800"
+      className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t border-border dark:bg-neutral-900/90"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="max-w-screen-sm mx-auto grid grid-cols-5">

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -88,7 +88,7 @@ export default function TaskRow({
         }}
         className="relative"
       >
-        <div className="rounded-2xl border bg-white shadow-card dark:bg-neutral-800 dark:border-neutral-700">
+        <div className="rounded-2xl border border-border bg-white shadow-card dark:bg-neutral-800">
           <div className="p-3 flex items-center gap-3">
             <button
               onClick={onOpen}
@@ -129,7 +129,7 @@ export default function TaskRow({
               >
                 <Check className="h-4 w-4" />
               </button>
-              <div className="flex items-center gap-1 ml-2 pl-2 border-l border-neutral-200 dark:border-neutral-600">
+              <div className="flex items-center gap-1 ml-2 pl-2 border-l border-neutral-200 dark:border-neutral-700">
                 <button
                   aria-label="Defer"
                   aria-keyshortcuts="s"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,10 @@ export default {
           foreground: "hsl(var(--secondary-foreground))",
         },
         muted: "hsl(var(--muted))",
+        border: "hsl(var(--border))",
+      },
+      borderColor: {
+        DEFAULT: "hsl(var(--border))",
       },
       borderRadius: {
         lg: "14px",


### PR DESCRIPTION
## Summary
- add `--border` color variable for light and dark themes
- expose border color to Tailwind and set default borderColor
- replace bare `border` utilities in components with `border-border` or neutral variants

## Testing
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a46c584bdc83248da6a056154c2805