### PR TITLE
Remove max width constraint from app views and bottom nav

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -354,7 +354,7 @@ export function TodayView() {
   }, [filteredTasks, taskWindow]);
 
   return (
-    <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
+    <div className="min-h-[100dvh] flex flex-col w-full">
       <header
         className="px-4 pb-2 sticky top-0 z-20 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}
@@ -638,7 +638,7 @@ export function TimelineView() {
   };
 
   return (
-    <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
+    <div className="min-h-[100dvh] flex flex-col w-full">
       <header
         className="px-4 pb-2 sticky top-0 z-20 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}
@@ -754,7 +754,7 @@ export function SettingsView() {
   }
 
   return (
-    <div className="min-h-[100dvh] flex flex-col w-full max-w-screen-sm mx-auto">
+    <div className="min-h-[100dvh] flex flex-col w-full">
       <header
         className="px-4 pb-2 sticky top-0 z-20 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -46,7 +46,7 @@ export default function BottomNav({ value }: { value: Tab }) {
       className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t dark:bg-neutral-900/90 dark:border-neutral-800"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
-      <div className="max-w-screen-sm mx-auto grid grid-cols-5">
+      <div className="grid grid-cols-5">
         <Item tab="today" label="Today" icon={<Leaf />} />
         <Item tab="timeline" label="Timeline" icon={<History />} />
         <Item tab="plants" label="Plants" icon={<Sprout />} />


### PR DESCRIPTION
## Summary
- Let Today, Timeline, and Settings views expand to full width
- Allow bottom navigation bar to stretch edge-to-edge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46d603e1c8324a2704bda4e4ae5ca