### PR TITLE
Handle single user mode for auth UI

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -746,6 +746,7 @@ export function TimelineView() {
 
 export function SettingsView() {
   const supabase = useRef(createSupabaseClient());
+  const singleUser = process.env.SINGLE_USER_MODE === "true";
 
   async function handleSignOut() {
     await supabase.current.auth.signOut();
@@ -789,12 +790,14 @@ export function SettingsView() {
             <div className="text-base font-medium">Theme</div>
             <ThemeToggle />
           </div>
-          <button
-            onClick={handleSignOut}
-            className="rounded-2xl border bg-white shadow-card p-4 text-left text-base font-medium dark:bg-neutral-800 dark:border-neutral-700"
-          >
-            Sign out
-          </button>
+          {!singleUser && (
+            <button
+              onClick={handleSignOut}
+              className="rounded-2xl border bg-white shadow-card p-4 text-left text-base font-medium dark:bg-neutral-800 dark:border-neutral-700"
+            >
+              Sign out
+            </button>
+          )}
         </section>
       </main>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createSupabaseClient } from "@/lib/supabase";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const singleUser = process.env.SINGLE_USER_MODE === "true";
+
+  useEffect(() => {
+    if (singleUser) {
+      window.location.href = "/app";
+    }
+  }, [singleUser]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -23,6 +30,14 @@ export default function LoginPage() {
     } catch (e: any) {
       setError(e.message || "Login failed");
     }
+  }
+
+  if (singleUser) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Login is disabled.</p>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Redirect / disable login page when SINGLE_USER_MODE is true
- Hide Settings sign out button in single-user mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46e04f3e483249ce1efa82241ac8e