### PR TITLE
feat: support single user mode with service key

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -13,6 +13,19 @@ export function ensureSupabaseEnv() {
 // Factory for an unauthenticated client
 export function createSupabaseClient(): SupabaseClient<Database> {
   const { url, anonKey } = ensureSupabaseEnv();
+  const singleUserMode = process.env.SINGLE_USER_MODE === "true";
+  if (singleUserMode) {
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!serviceKey) {
+      throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY");
+    }
+    return createClient<Database>(url, serviceKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
   return createClient<Database>(url, anonKey);
 }
 


### PR DESCRIPTION
## Summary
- allow createSupabaseClient to use service role key when SINGLE_USER_MODE is enabled
- disable session persistence and token refresh for single-user client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a46dfebcac83248ab9a92905f05c39