### PR TITLE
test: restore fetch in usePlants tests

### DIFF
--- a/app/app/plants/usePlants.test.tsx
+++ b/app/app/plants/usePlants.test.tsx
@@ -5,12 +5,15 @@ import { renderHook, waitFor } from '@testing-library/react';
 import usePlants from './usePlants';
 
 describe('usePlants', () => {
+  let originalFetch: typeof global.fetch;
+
   beforeEach(() => {
-    // @ts-ignore
-    global.fetch = jest.fn();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn() as jest.Mock;
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     jest.resetAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- mock `global.fetch` with `jest.Mock` instead of `@ts-ignore`
- store original `fetch` and restore after each test to prevent leakage

## Testing
- `npm test -- app/app/plants/usePlants.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a48a9957b48324b383076f4a95f250