### PR TITLE
Refactor timeout refs

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -136,7 +136,7 @@ export function TodayView() {
     message: string;
     action?: { label: string; onClick: () => void };
   }>({ visible: false, message: "" });
-  const timer = useRef<number | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // data
   const [tasks, setTasks] = useState<TaskDTO[]>([]);
@@ -234,7 +234,6 @@ export function TodayView() {
   ) => {
     if (timer.current) window.clearTimeout(timer.current);
     setSnackbar({ visible: true, message: m, action });
-    // @ts-ignore
     timer.current = window.setTimeout(
       () => setSnackbar({ visible: false, message: "" }),
       5000,

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -13,7 +13,7 @@ export default function PlantsView() {
     message: string;
     action?: { label: string; onClick: () => void };
   }>({ visible: false, message: "" });
-  const timer = useRef<number | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sortedItems =
     items?.slice().sort((a, b) => {
       const roomA = a.room || "";
@@ -83,7 +83,6 @@ export default function PlantsView() {
               },
             },
           });
-          // @ts-ignore
           timer.current = window.setTimeout(
             () => setSnackbar({ visible: false, message: "" }),
             5000,


### PR DESCRIPTION
## Summary
- use `ReturnType<typeof setTimeout>` for timer refs
- remove `// @ts-ignore` around `window.setTimeout`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48a9c0a588324904793c7a27b8b45