### PR TITLE
refactor: handle unknown errors in species autosuggest

### DIFF
--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -114,8 +114,12 @@ export default function SpeciesAutosuggest({
           setLoading(false);
           setError(false);
         }
-      } catch (e) {
-        if ((e as any).name !== 'AbortError' && controllers.get(query) === controller) {
+      } catch (e: unknown) {
+        if (
+          e instanceof Error &&
+          e.name !== 'AbortError' &&
+          controllers.get(query) === controller
+        ) {
           console.error('species search failed', e);
           setSuggestions(staticSuggestions);
           setError(true);


### PR DESCRIPTION
## Summary
- type the `catch` parameter as `unknown`
- ensure error check uses `instanceof Error` and compare `name`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48b53f8c483248c749c9986f57cbf