### PR TITLE
Use DialogBackdrop in AddPlantModal

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import React, { useEffect, useState, useRef, useId } from 'react';
-import { Dialog } from '@headlessui/react';
+import {
+  Dialog,
+  DialogBackdrop,
+  // (optional) DialogPanel, DialogTitle
+} from '@headlessui/react';
 import { X, ArrowLeft, ArrowRight, Check } from 'lucide-react';
 import {
   BasicsFields,
@@ -335,7 +339,7 @@ export default function AddPlantModal({
         initialFocus={firstFieldRef}
         aria-labelledby={titleId}
       >
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30" />
+        <DialogBackdrop className="fixed inset-0 z-40 bg-black/30" />
         <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
           <Dialog.Panel className="relative z-50 w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-card sm:max-h-[90vh] flex flex-col">
             <header className="sticky top-0 bg-background border-b p-6">


### PR DESCRIPTION
## Summary
- update AddPlantModal to import `DialogBackdrop` from Headless UI
- replace deprecated `<Dialog.Overlay>` with `<DialogBackdrop>`

## Testing
- `npm test` *(fails: Jest failed to parse TypeScript config; Cannot find module 'next/jest')*
- `npm run build` *(fails: Failed to fetch font files; Build failed because of webpack errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors in existing project files)*

------
https://chatgpt.com/codex/tasks/task_e_68a48cc694708324bba3cceea88842f6