### PR TITLE
feat: add progress text and field placeholders

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -349,13 +349,18 @@ export default function AddPlantModal({
               >
                 Add Plant
               </Dialog.Title>
-              <div className="mt-4 flex gap-2">
-                {[0, 1, 2].map((n) => (
-                  <div
-                    key={n}
-                    className={`h-1 flex-1 rounded ${step >= n ? 'bg-primary' : 'bg-neutral-200'}`}
-                  />
-                ))}
+              <div className="mt-4">
+                <p className="text-sm text-neutral-600" aria-live="polite">
+                  {`Step ${step + 1} of 3: ${['Basics', 'Environment', 'Care plan'][step]}`}
+                </p>
+                <div className="mt-2 flex gap-2" aria-hidden="true">
+                  {[0, 1, 2].map((n) => (
+                    <div
+                      key={n}
+                      className={`h-1 flex-1 rounded ${step >= n ? 'bg-primary' : 'bg-neutral-200'}`}
+                    />
+                  ))}
+                </div>
               </div>
             </header>
             <div className="flex-1 overflow-y-auto p-6">

--- a/components/RoomSelector.tsx
+++ b/components/RoomSelector.tsx
@@ -76,7 +76,7 @@ export default function RoomSelector({
         <input
           ref={inputRef}
           className="input flex-1"
-          placeholder="Add room"
+          placeholder="e.g., Living Room"
           value={newRoom}
           onChange={(e) => setNewRoom(e.target.value)}
         />

--- a/components/SpeciesAutosuggest.tsx
+++ b/components/SpeciesAutosuggest.tsx
@@ -165,7 +165,7 @@ export default function SpeciesAutosuggest({
           onBlur?.();
           setTimeout(() => setOpen(false), 100);
         }}
-        placeholder="e.g., Monstera deliciosa"
+        placeholder="e.g., Spider Plant"
       />
       {open && (
         <ul


### PR DESCRIPTION
## Summary
- add step progress text to Add Plant wizard
- provide example placeholders for plant name and room

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e5a5929c8324ad16750e941fd4ce