### PR TITLE
Improve accessibility for icons and controls

### DIFF
--- a/components/ChipSelect.test.tsx
+++ b/components/ChipSelect.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ChipSelect } from './PlantForm';
+
+describe('ChipSelect', () => {
+  it('allows arrow key navigation and selection', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ChipSelect options={['A', 'B', 'C']} value="A" onChange={onChange} />
+    );
+    const first = getByLabelText('A');
+    first.focus();
+    await user.keyboard('{ArrowRight}');
+    const second = getByLabelText('B');
+    expect(document.activeElement).toBe(second);
+    fireEvent.keyDown(second, { key: ' ' });
+    expect(onChange).toHaveBeenCalledWith('B');
+  });
+
+  it('only selected chip is tabbable', () => {
+    const { getByLabelText } = render(
+      <ChipSelect options={['A', 'B']} value="A" onChange={() => {}} />
+    );
+    const first = getByLabelText('A');
+    const second = getByLabelText('B');
+    expect(first).toHaveAttribute('tabindex', '0');
+    expect(second).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
 import type { AiCareSuggestion } from '@/lib/aiCare';
 import { z } from 'zod';
@@ -128,7 +128,7 @@ const emptyValidation: Validation = {
   markTouched: () => {},
 };
 
-function ChipSelect({
+export function ChipSelect({
   options,
   value,
   onChange,
@@ -137,18 +137,36 @@ function ChipSelect({
   value: string;
   onChange: (v: string) => void;
 }) {
+  const refs = useRef<HTMLButtonElement[]>([]);
   return (
-    <div className="flex gap-2">
-      {options.map((opt) => (
+    <div className="flex gap-2" role="radiogroup" aria-label="Options">
+      {options.map((opt, i) => (
         <button
           key={opt}
+          ref={(el) => (refs.current[i] = el!)}
           type="button"
+          role="radio"
+          aria-checked={value === opt}
+          aria-label={opt}
+          tabIndex={value === opt ? 0 : -1}
           className={`min-w-11 min-h-11 px-3 py-2 rounded-full border text-sm flex items-center justify-center ${
             value === opt
               ? 'bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900'
               : 'bg-white text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100'
           }`}
           onClick={() => onChange(opt)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+              e.preventDefault();
+              refs.current[(i + 1) % options.length]?.focus();
+            } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+              e.preventDefault();
+              refs.current[(i - 1 + options.length) % options.length]?.focus();
+            } else if (e.key === ' ' || e.key === 'Enter') {
+              e.preventDefault();
+              onChange(opt);
+            }
+          }}
         >
           {opt}
         </button>

--- a/components/PlantTypeIcons.tsx
+++ b/components/PlantTypeIcons.tsx
@@ -1,0 +1,22 @@
+import { Leaf, Sun, Droplet } from 'lucide-react';
+import React from 'react';
+
+export type PlantType = 'foliage' | 'sun' | 'water';
+
+const icons: Record<PlantType, { icon: React.ComponentType<any>; label: string }> = {
+  foliage: { icon: Leaf, label: 'Foliage plant' },
+  sun: { icon: Sun, label: 'Sun-loving plant' },
+  water: { icon: Droplet, label: 'Water-loving plant' },
+};
+
+export default function PlantTypeIcon({ type }: { type: PlantType }) {
+  const { icon: Icon, label } = icons[type];
+  return (
+    <span
+      className="inline-flex items-center justify-center text-neutral-900 dark:text-neutral-100"
+      aria-label={label}
+    >
+      <Icon aria-hidden="true" />
+    </span>
+  );
+}

--- a/components/Stepper.test.tsx
+++ b/components/Stepper.test.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState } from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Stepper from './Stepper';
 
@@ -29,6 +30,25 @@ describe('Stepper', () => {
     fireEvent.change(input, { target: { value: '123' } });
     fireEvent.blur(input);
     expect(input.value).toBe('120');
+  });
+
+  it('supports tab order and arrow keys on buttons', async () => {
+    function Wrapper() {
+      const [v, setV] = useState('1');
+      return <Stepper value={v} onChange={setV} ariaLabel="Quantity" />;
+    }
+    const { getByLabelText } = render(<Wrapper />);
+    const user = userEvent.setup();
+    await user.tab();
+    expect(getByLabelText('Decrease value')).toHaveFocus();
+    await user.tab();
+    const input = getByLabelText('Quantity') as HTMLInputElement;
+    expect(input).toHaveFocus();
+    await user.tab();
+    const inc = getByLabelText('Increase value');
+    expect(inc).toHaveFocus();
+    fireEvent.keyDown(inc, { key: 'ArrowUp' });
+    expect(input.value).toBe('2');
   });
 });
 

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -7,11 +7,13 @@ export default function Stepper({
   onChange,
   min = 0,
   step = 1,
+  ariaLabel = 'Value',
 }: {
   value: string;
   onChange: (v: string) => void;
   min?: number;
   step?: number;
+  ariaLabel?: string;
 }) {
   const num = Number(value) || 0;
   const clamp = (n: number) => {
@@ -40,6 +42,15 @@ export default function Stepper({
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     onChange(String(clamp(Number(e.target.value) || 0)));
   };
+  const handleButtonKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      inc();
+    } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      dec();
+    }
+  };
   return (
     <div className="flex items-center gap-2">
       <button
@@ -47,8 +58,9 @@ export default function Stepper({
         className="w-11 h-11 flex items-center justify-center border rounded-2xl shadow-md bg-white text-neutral-900 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary transition-colors dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
         onClick={dec}
         aria-label="Decrease value"
+        onKeyDown={handleButtonKeyDown}
       >
-        <Minus className="w-4 h-4 text-primary" />
+        <Minus className="w-4 h-4 text-neutral-900 dark:text-neutral-100" aria-hidden="true" />
       </button>
       <input
         type="number"
@@ -58,14 +70,16 @@ export default function Stepper({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
+        aria-label={ariaLabel}
       />
       <button
         type="button"
         className="w-11 h-11 flex items-center justify-center border rounded-2xl shadow-md bg-white text-neutral-900 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary transition-colors dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
         onClick={inc}
         aria-label="Increase value"
+        onKeyDown={handleButtonKeyDown}
       >
-        <Plus className="w-4 h-4 text-primary" />
+        <Plus className="w-4 h-4 text-neutral-900 dark:text-neutral-100" aria-hidden="true" />
       </button>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@tailwindcss/postcss": "^4.1.12",
         "@testing-library/jest-dom": "^6.7.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/node": "24.3.0",
         "@types/react": "^18.2.21",
@@ -2671,6 +2672,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "24.3.0",
     "@types/react": "^18.2.21",


### PR DESCRIPTION
## Summary
- add PlantTypeIcon component with WCAG-compliant contrast and labels
- enable keyboard navigation and ARIA for ChipSelect and Stepper components
- test focus order, keyboard interaction, and screen-reader labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ac0cbfc88324ae528a9059c761f5