### PR TITLE
feat: surface care tips while adding plants

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -20,6 +20,7 @@ import {
 import { plantFormSchema, plantFieldSchemas } from '@/lib/plantFormSchema';
 import type { AiCareSuggestion } from '@/lib/aiCare';
 import { fetchJson, FetchJsonError } from '@/lib/fetchJson';
+import useCareTips from './useCareTips';
 
 export function todayLocalYYYYMMDD(): string {
   const d = new Date();
@@ -69,6 +70,8 @@ export default function AddPlantModal({
     ? plantFieldSchemas.name.safeParse(values.name).success &&
       plantFieldSchemas.roomId.safeParse(values.roomId).success
     : false;
+
+  const careTips = useCareTips(values);
 
   const validationMessage =
     step === 0 && !basicsValid
@@ -384,6 +387,7 @@ export default function AddPlantModal({
                       defaults={defaults || undefined}
                       nameInputRef={firstFieldRef}
                       onSaveDefault={saveDefault}
+                      careTips={careTips}
                     />
                   )}
                   {step === 1 && <EnvironmentFields state={values} setState={setValues} />}

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -164,11 +164,13 @@ export function BasicsFields({
   defaults,
   nameInputRef,
   onSaveDefault,
+  careTips,
 }: SectionProps & {
   validation?: Validation;
   defaults?: { pot: string; potMaterial: string; light: string };
   nameInputRef?: React.RefObject<HTMLInputElement>;
   onSaveDefault?: (field: 'pot' | 'potMaterial' | 'light', value: string) => void;
+  careTips?: { potMaterial?: string; light?: string };
 }) {
   const { errors, touched, validate, markTouched } = validation;
   return (
@@ -268,15 +270,8 @@ export function BasicsFields({
                 Save as new default
               </button>
             )}
-          {state.pot && (
-            <p className="hint">
-              {state.pot}{' '}
-              {state.potMaterial === 'Terracotta'
-                ? 'terracotta dries faster than plastic.'
-                : state.potMaterial === 'Plastic'
-                ? 'plastic retains moisture longer.'
-                : 'ceramic balances moisture.'}
-            </p>
+          {careTips?.potMaterial && (
+            <p className="hint">{careTips.potMaterial}</p>
           )}
         </Field>
         <Field label="Light" defaulted={defaults?.light === state.light}>
@@ -294,6 +289,7 @@ export function BasicsFields({
               Save as new default
             </button>
           )}
+          {careTips?.light && <p className="hint">{careTips.light}</p>}
         </Field>
       </div>
     </div>

--- a/components/useCareTips.ts
+++ b/components/useCareTips.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useMemo } from 'react';
+import { PlantFormValues } from './PlantForm';
+
+export type CareTipMap = {
+  potMaterial?: string;
+  light?: string;
+};
+
+export function useCareTips(values: PlantFormValues | null): CareTipMap {
+  return useMemo(() => {
+    if (!values) return {};
+    const tips: CareTipMap = {};
+
+    switch (values.potMaterial) {
+      case 'Terracotta':
+        tips.potMaterial = 'Terracotta dries faster—water sooner.';
+        break;
+      case 'Plastic':
+        tips.potMaterial = 'Plastic retains moisture—avoid overwatering.';
+        break;
+      case 'Ceramic':
+        tips.potMaterial = 'Ceramic balances moisture.';
+        break;
+    }
+
+    switch (values.light) {
+      case 'Low':
+        tips.light = 'Low light slows growth—water less often.';
+        break;
+      case 'Bright':
+        tips.light = 'Bright light increases water needs.';
+        break;
+    }
+
+    return tips;
+  }, [values?.potMaterial, values?.light]);
+}
+
+export default useCareTips;


### PR DESCRIPTION
## Summary
- add `useCareTips` hook to provide field-dependent care tips
- show pot material and light level tips in plant form
- wire tip hook into AddPlantModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ac06c0f08324a1bf9b29aa90471c