### PR TITLE
Prefill new plant location via geolocation

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -62,6 +62,7 @@ export default function AddPlantModal({
   } | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [locationTag, setLocationTag] = useState<string | null>(null);
   const validationId = useId();
   const saveErrorId = useId();
   const canSubmit = values ? plantFormSchema.safeParse(values).success : false;
@@ -122,6 +123,7 @@ export default function AddPlantModal({
       setNotice(null);
       setStep(0);
       setPlanSource({ type: 'manual' });
+      setLocationTag(null);
       let stored: any = {};
       try {
         stored = JSON.parse(localStorage.getItem('plantDefaults') || '{}');
@@ -147,6 +149,16 @@ export default function AddPlantModal({
         lastWatered: todayLocalYYYYMMDD(),
         lastFertilized: todayLocalYYYYMMDD(),
       };
+      if ('geolocation' in navigator) {
+        try {
+          const pos = await new Promise<GeolocationPosition>((resolve, reject) =>
+            navigator.geolocation.getCurrentPosition(resolve, reject)
+          );
+          base.lat = pos.coords.latitude.toFixed(6);
+          base.lon = pos.coords.longitude.toFixed(6);
+          setLocationTag('Current location');
+        } catch {}
+      }
       setDefaults({
         pot: base.pot,
         potMaterial: base.potMaterial,
@@ -386,7 +398,15 @@ export default function AddPlantModal({
                       onSaveDefault={saveDefault}
                     />
                   )}
-                  {step === 1 && <EnvironmentFields state={values} setState={setValues} />}
+                  {step === 1 && (
+                    <EnvironmentFields
+                      state={values}
+                      setState={setValues}
+                      locationTag={locationTag}
+                      onLocationEdit={() => setLocationTag(null)}
+                      onUseCurrentLocation={() => setLocationTag('Current location')}
+                    />
+                  )}
                   {step === 2 && (
                     <CarePlanFields
                       state={values}

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -304,7 +304,15 @@ export function EnvironmentFields({
   state,
   setState,
   validation = emptyValidation,
-}: SectionProps & { validation?: Validation }) {
+  locationTag,
+  onLocationEdit,
+  onUseCurrentLocation,
+}: SectionProps & {
+  validation?: Validation;
+  locationTag?: string | null;
+  onLocationEdit?: () => void;
+  onUseCurrentLocation?: () => void;
+}) {
   const { errors, touched, validate, markTouched } = validation;
   const [showMore, setShowMore] = useState(false);
   const [address, setAddress] = useState('');
@@ -322,6 +330,7 @@ export function EnvironmentFields({
         validate('lat', lat);
         validate('lon', lon);
         setGeoError(null);
+        onUseCurrentLocation?.();
       },
       (err) => {
         if (err.code === err.PERMISSION_DENIED) {
@@ -348,6 +357,7 @@ export function EnvironmentFields({
         markTouched('lon');
         validate('lat', lat);
         validate('lon', lon);
+        onLocationEdit?.();
       }
     } catch {}
   }
@@ -402,23 +412,37 @@ export function EnvironmentFields({
 
       <Field label="Location (for weather)">
         <div className="grid gap-2">
-          <button
-            type="button"
-            className="btn-secondary"
-            onClick={useCurrentLocation}
-            title="We’ll tailor watering to local weather."
-          >
-            Use current location
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={useCurrentLocation}
+              title="We’ll tailor watering to local weather."
+            >
+              Use current location
+            </button>
+            {locationTag && (
+              <span className="rounded-full border bg-white px-2 py-1 text-xs shadow-sm">
+                {locationTag}
+              </span>
+            )}
+          </div>
           {geoError && <p className="text-xs text-red-600">{geoError}</p>}
           <div className="flex gap-2">
             <input
               className="input flex-1"
               value={address}
-              onChange={(e) => setAddress(e.target.value)}
+              onChange={(e) => {
+                setAddress(e.target.value);
+                onLocationEdit?.();
+              }}
               placeholder="Search address"
             />
-            <button type="button" className="btn-secondary" onClick={lookupAddress}>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={lookupAddress}
+            >
               Search
             </button>
           </div>
@@ -433,6 +457,7 @@ export function EnvironmentFields({
                     setState({ ...state, lat: v });
                     markTouched('lat');
                     validate('lat', v);
+                    onLocationEdit?.();
                   }}
                   onBlur={() => {
                     markTouched('lat');
@@ -457,6 +482,7 @@ export function EnvironmentFields({
                     setState({ ...state, lon: v });
                     markTouched('lon');
                     validate('lon', v);
+                    onLocationEdit?.();
                   }}
                   onBlur={() => {
                     markTouched('lon');


### PR DESCRIPTION
## Summary
- request geolocation when Add Plant modal opens and tag it as current location
- expose location tag handling to EnvironmentFields so users can override coordinates

## Testing
- `npm test` *(fails: Cannot find module 'next/jest')*


------
https://chatgpt.com/codex/tasks/task_e_68a4abf1d3e08324a7745b17a5b4e621