### PR TITLE
fix: define PottedPlant icon

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -25,6 +25,7 @@ import {
   Droplet,
   FlaskRound,
   Sprout,
+  Sprout as PottedPlant,
   Home,
   X,
   Filter as FilterIcon,


### PR DESCRIPTION
## Summary
- alias Sprout icon as PottedPlant to fix runtime reference error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4af45a9fc832495739e1f2a09bde2