### PR TITLE
Redirect to PlantCreated page after adding plant

### DIFF
--- a/app/app/plants/[id]/created/page.tsx
+++ b/app/app/plants/[id]/created/page.tsx
@@ -1,0 +1,5 @@
+import PlantCreated from '@/components/PlantCreated';
+
+export default function PlantCreatedPage({ params }: { params: { id: string } }) {
+  return <PlantCreated plantId={params.id} />;
+}

--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -22,6 +22,7 @@ import { plantFormSchema, plantFieldSchemas } from '@/lib/plantFormSchema';
 import type { AiCareSuggestion } from '@/lib/aiCare';
 import { fetchJson, FetchJsonError } from '@/lib/fetchJson';
 import useCareTips from './useCareTips';
+import { useRouter } from 'next/navigation';
 
 export function todayLocalYYYYMMDD(): string {
   const d = new Date();
@@ -77,6 +78,7 @@ export default function AddPlantModal({
     : false;
 
   const careTips = useCareTips(values);
+  const router = useRouter();
 
   const validationMessage =
     step === 0 && !basicsValid
@@ -393,6 +395,7 @@ export default function AddPlantModal({
       } catch {}
       onCreate({ id: created.id, name: created.name || current.name });
       close();
+      router.push(`/app/plants/${created.id}/created`);
     } catch (e: unknown) {
       const err = e as FetchJsonError<{
         error?: string;

--- a/components/PlantCreated.tsx
+++ b/components/PlantCreated.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from './ui/button';
+import { Camera, Share2, Bell } from 'lucide-react';
+
+export default function PlantCreated({ plantId }: { plantId: string }) {
+  return (
+    <div className="p-6 text-center space-y-6">
+      <h1 className="text-xl font-display font-semibold">Plant Added!</h1>
+      <div className="flex flex-col gap-3">
+        <Button className="w-full">
+          <Camera className="mr-2 h-4 w-4" /> Add a photo
+        </Button>
+        <Button className="w-full">
+          <Share2 className="mr-2 h-4 w-4" /> Share with friends
+        </Button>
+        <Button className="w-full">
+          <Bell className="mr-2 h-4 w-4" /> Set reminder
+        </Button>
+      </div>
+      <Link href={`/app/plants/${plantId}`} className="text-primary underline block">
+        View plant
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Redirect to new plant confirmation page after successfully saving a plant
- Add PlantCreated component with quick options and link to plant details
- Wire up /app/plants/[id]/created route to render confirmation screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0404ccc83249142de5682fb5f5e