### PR TITLE
docs: add UX polish tasks for core pages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,13 @@ This document outlines upcoming work for the Kay Maria plant care app.
   - [ ] Loading states
   - [ ] Smoke tests
 
+- [ ] Core pages UX polish
+  - [ ] Plants page (`/app/plants`)
+  - [ ] Today page (`/app/today`)
+  - [ ] Timeline page (`/app/timeline`)
+  - [ ] Insights page (`/app/insights`)
+  - [ ] Settings page (`/app/settings`)
+
 - [ ] Multi-device sync
   - [x] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
   - [x] Real-time data sync across devices


### PR DESCRIPTION
## Summary
- add roadmap items to polish UX for Plants, Today, Timeline, Insights, and Settings pages

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2dc42588324aa50d9be086340cf