### PR TITLE
feat: allow optional dates in plant form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion with real-time task syncing across devices. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
 
-The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections.
+The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values.
 
 ## Quick Start
 Kay Maria is intended to run in single-user mode by default.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
 
 - [ ] Add Plant form polish
    - [x] UI styling
-   - [ ] Form validation
+   - [x] Form validation
    - [ ] Backend persistence
    - [ ] Smoke tests
 

--- a/lib/plantFormSchema.test.ts
+++ b/lib/plantFormSchema.test.ts
@@ -8,8 +8,8 @@ describe('plantFormSchema', () => {
       waterEvery: '1',
       waterAmount: '10',
       fertEvery: '1',
-      lastWatered: '2024-01-01',
-      lastFertilized: '2024-01-01',
+      lastWatered: '',
+      lastFertilized: '',
     });
     expect(res.success).toBe(false);
     const errors = (res as any).error.flatten().fieldErrors;
@@ -24,8 +24,8 @@ describe('plantFormSchema', () => {
       waterEvery: '0',
       waterAmount: '9',
       fertEvery: '0',
-      lastWatered: '2024-01-01',
-      lastFertilized: '2024-01-01',
+      lastWatered: '',
+      lastFertilized: '',
     });
     expect(res.success).toBe(false);
     const errors = (res as any).error.flatten().fieldErrors;
@@ -43,6 +43,19 @@ describe('plantFormSchema', () => {
       fertEvery: '1',
       lastWatered: '2024-01-01',
       lastFertilized: '2024-01-01',
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('allows empty date fields', () => {
+    const res = plantFormSchema.safeParse({
+      name: 'A',
+      roomId: 'r1',
+      waterEvery: '1',
+      waterAmount: '10',
+      fertEvery: '1',
+      lastWatered: '',
+      lastFertilized: '',
     });
     expect(res.success).toBe(true);
   });

--- a/lib/plantFormSchema.ts
+++ b/lib/plantFormSchema.ts
@@ -6,8 +6,14 @@ export const plantFieldSchemas = {
   waterEvery: z.coerce.number().min(1, 'Must be at least 1 day'),
   waterAmount: z.coerce.number().min(10, 'Must be at least 10 ml'),
   fertEvery: z.coerce.number().min(1, 'Must be at least 1 day'),
-  lastWatered: z.coerce.date({ invalid_type_error: 'Enter a valid date' }),
-  lastFertilized: z.coerce.date({ invalid_type_error: 'Enter a valid date' }),
+  lastWatered: z.preprocess(
+    (v) => (v === '' || v === undefined ? undefined : v),
+    z.coerce.date({ invalid_type_error: 'Enter a valid date' }).optional(),
+  ),
+  lastFertilized: z.preprocess(
+    (v) => (v === '' || v === undefined ? undefined : v),
+    z.coerce.date({ invalid_type_error: 'Enter a valid date' }).optional(),
+  ),
 };
 
 export const plantFormSchema = z.object(plantFieldSchemas);


### PR DESCRIPTION
## Summary
- allow optional last watered and fertilized dates in plant form schema
- cover optional date fields with unit tests
- document form validation and mark roadmap task complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b396c1c8832487be773445ff0b39