### PR TITLE
Enable task creation when adding plants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion with real-time task syncing across devices. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
 
-The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values.
+The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values. Submitting the form now persists the plant to the backend and pre-creates care tasks.
 
 ## Quick Start
 Kay Maria is intended to run in single-user mode by default.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
 - [ ] Add Plant form polish
    - [x] UI styling
    - [x] Form validation
-   - [ ] Backend persistence
+   - [x] Backend persistence
    - [ ] Smoke tests
 
 - [ ] Plant detail page UX polish

--- a/components/PlantForm.test.ts
+++ b/components/PlantForm.test.ts
@@ -1,0 +1,26 @@
+import { plantValuesToSubmit, type PlantFormValues } from './PlantForm';
+
+describe('plantValuesToSubmit', () => {
+  it('sets createTasks flag', () => {
+    const values: PlantFormValues = {
+      name: 'Test Plant',
+      roomId: 'room-1',
+      species: 'Ficus',
+      pot: '10cm',
+      potMaterial: 'Ceramic',
+      light: 'Bright',
+      indoor: 'Indoor',
+      drainage: 'ok',
+      soil: 'Potting mix',
+      humidity: 'Medium',
+      waterEvery: '7',
+      waterAmount: '500',
+      fertEvery: '30',
+      fertFormula: '10-10-10',
+      lastWatered: '',
+      lastFertilized: '',
+    };
+    const result = plantValuesToSubmit(values);
+    expect(result.createTasks).toBe(true);
+  });
+});

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -48,12 +48,13 @@ export type PlantFormSubmit = {
   lon?: number;
   lastWateredAt?: string;
   lastFertilizedAt?: string;
+  createTasks?: boolean;
   rules: {
     type: 'water' | 'fertilize';
     intervalDays: number;
     amountMl?: number;
     formula?: string;
-}[];
+  }[];
 };
 
 export type PlanSource =
@@ -95,6 +96,7 @@ export function plantValuesToSubmit(s: PlantFormValues): PlantFormSubmit {
     base.lat = Number(s.lat);
     base.lon = Number(s.lon);
   }
+  base.createTasks = true;
   return base;
 }
 


### PR DESCRIPTION
## Summary
- automatically request backend to pre-create care tasks when submitting Add Plant form
- document backend persistence and update roadmap
- add unit test for `plantValuesToSubmit`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b57e2a8c83248ac93f590c8a8627