### PR TITLE
Add Add Plant modal smoke test and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion with real-time task syncing across devices. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
 
-The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values. Submitting the form now persists the plant to the backend and pre-creates care tasks.
+The Add Plant modal uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values. Submitting the form now persists the plant to the backend and pre-creates care tasks. A smoke test exercises the full add flow to guard against regressions.
 
 ## Quick Start
 Kay Maria is intended to run in single-user mode by default.
@@ -53,6 +53,7 @@ After pulling new changes:
 
 ## Testing
 - Unit tests: `npm test`
+- Add Plant form smoke test: [`components/AddPlantModal.test.tsx`](./components/AddPlantModal.test.tsx)
 - Manual scenarios live in [docs/manual-test-cases.md](./docs/manual-test-cases.md)
 - End-to-end tests: `npm run test:e2e`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
    - [x] UI styling
    - [x] Form validation
    - [x] Backend persistence
-   - [ ] Smoke tests
+   - [x] Smoke tests
 
 - [ ] Plant detail page UX polish
   - [ ] UI styling

--- a/components/AddPlantModal.test.tsx
+++ b/components/AddPlantModal.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AddPlantModal from './AddPlantModal';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('./useCareTips', () => jest.fn(() => ({})));
+
+jest.mock('@/lib/fetchJson', () => ({
+  fetchJson: jest.fn(),
+}));
+
+describe('AddPlantModal', () => {
+  beforeEach(() => {
+    push.mockReset();
+    global.fetch = jest.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === '/api/rooms') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 'room-1', name: 'Living Room' }],
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [],
+      } as Response);
+    }) as any;
+    const { fetchJson } = require('@/lib/fetchJson');
+    (fetchJson as jest.Mock).mockImplementation((url: string) => {
+      if (url.startsWith('/api/plants?')) {
+        return Promise.resolve([]);
+      }
+      if (url === '/api/plants') {
+        return Promise.resolve({ id: 'p1', name: 'Fern' });
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it('allows adding a plant', async () => {
+    const onCreate = jest.fn();
+    render(
+      <AddPlantModal
+        open={true}
+        onOpenChange={() => {}}
+        defaultRoomId="room-1"
+        onCreate={onCreate}
+      />
+    );
+
+    const nameInput = await screen.findByPlaceholderText('e.g., Monstera deliciosa');
+    fireEvent.change(nameInput, { target: { value: 'Fern' } });
+
+    for (let i = 0; i < 3; i++) {
+      const next = screen.getByRole('button', { name: /next/i });
+      fireEvent.click(next);
+    }
+
+    const confirm = screen.getByRole('button', { name: /confirm plan/i });
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith({ id: 'p1', name: 'Fern' }));
+    expect(push).toHaveBeenCalledWith('/app/plants/p1/created');
+  });
+});


### PR DESCRIPTION
## Summary
- add smoke test covering Add Plant modal flow
- document smoke test in README
- mark Add Plant form smoke tests as complete in roadmap

## Testing
- `npm test`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68a4e21152d48324a18b756fb927c24a