### PR TITLE
Add smoke test for Add Plant modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After pulling new changes:
 
 ## Testing
 - Unit tests: `npm test`
+- Includes a smoke test for the Add Plant modal
 - Manual scenarios live in [docs/manual-test-cases.md](./docs/manual-test-cases.md)
 - End-to-end tests: `npm run test:e2e`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
    - [x] UI styling
    - [x] Form validation
    - [x] Backend persistence
-   - [ ] Smoke tests
+   - [x] Smoke tests
 
 - [ ] Plant detail page UX polish
   - [ ] UI styling

--- a/components/AddPlantModal.test.tsx
+++ b/components/AddPlantModal.test.tsx
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import AddPlantModal from './AddPlantModal';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/lib/fetchJson', () => ({
+  fetchJson: jest.fn().mockResolvedValue({}),
+  FetchJsonError: class extends Error {},
+}));
+
+jest.mock('./useCareTips', () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+// Mock fetch for RoomSelector and other network calls
+beforeAll(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [],
+  }) as any;
+});
+
+afterAll(() => {
+  (global.fetch as any).mockRestore?.();
+});
+
+describe('AddPlantModal', () => {
+  it('renders the Basics step when open', async () => {
+    render(
+      <AddPlantModal
+        open={true}
+        onOpenChange={() => {}}
+        defaultRoomId="room-1"
+        onCreate={() => {}}
+      />
+    );
+    // heading for first step should appear
+    expect(await screen.findByText('Basics')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest smoke test for Add Plant modal
- document new smoke test in README
- mark Add Plant form smoke tests complete in roadmap

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a4e32061f483248f0eed192dc832a6