### PR TITLE
feat: widen add plant modal on large screens

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -466,7 +466,7 @@ export default function AddPlantModal({
       >
         <DialogBackdrop className="fixed inset-0 z-40 bg-black/30" />
         <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
-          <Dialog.Panel className="relative z-50 w-full h-full sm:h-auto sm:max-w-lg bg-background rounded-2xl shadow-card sm:max-h-[90vh] flex flex-col">
+          <Dialog.Panel className="relative z-50 w-full h-full sm:h-auto sm:max-w-xl md:max-w-2xl bg-background rounded-2xl shadow-card sm:max-h-[90vh] flex flex-col">
             <header className="sticky top-0 bg-background border-b p-6">
               <Dialog.Title
                 id={titleId}


### PR DESCRIPTION
## Summary
- increase AddPlantModal dialog max-width at larger breakpoints

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6268ff08324861c1131194d3e38