### PR TITLE
Improve AddPlantModal step title readability

### DIFF
--- a/components/AddPlantModal.tsx
+++ b/components/AddPlantModal.tsx
@@ -482,7 +482,7 @@ export default function AddPlantModal({
                   />
                 ))}
               </div>
-              <div className="mt-2 flex justify-between text-xs text-neutral-600">
+              <div className="mt-1 flex justify-between text-sm text-neutral-700 dark:text-neutral-300">
                 {stepTitles.map((title, n) => (
                   <span
                     key={title}


### PR DESCRIPTION
## Summary
- make step titles more readable by increasing font size to `text-sm` and improving contrast with updated neutral colors
- adjust top margin on step titles to keep header spacing consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e824bb8483248730791ee6940b85