### PR TITLE
Add smoke test for plant detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 
 The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries and numeric values. Submitting the form now persists the plant to the backend and pre-creates care tasks.
 
-The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout.
+The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. Basic smoke tests verify the page renders successfully.
 
 ## Quick Start
 Kay Maria is intended to run in single-user mode by default.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ This document outlines upcoming work for the Kay Maria plant care app.
   - [x] UI styling
   - [x] Navigation improvements
   - [x] Loading states
-  - [ ] Smoke tests
+  - [x] Smoke tests
 
 - [ ] Core pages UX polish
   - [ ] Plants page (`/app/plants`)

--- a/app/app/plants/__tests__/PlantDetailClient.test.tsx
+++ b/app/app/plants/__tests__/PlantDetailClient.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import PlantDetailClient from '../[id]/PlantDetailClient';
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+jest.mock('@/components/EditPlantModal', () => () => null);
+jest.mock('@/components/BottomNav', () => () => null);
+jest.mock('@/components/CareSummary', () => () => <div>CareSummary</div>);
+
+describe('PlantDetailClient', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn((url: RequestInfo) => {
+      const href = typeof url === 'string' ? url : url.toString();
+      if (href.includes('/weather')) {
+        return Promise.resolve({ ok: true, json: async () => ({ temperature: 20 }) }) as any;
+      }
+      return Promise.resolve({ ok: true, json: async () => [] }) as any;
+    }) as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('renders plant name', async () => {
+    render(
+      <PlantDetailClient
+        plant={{ id: '1', userId: 'u1', name: 'Fern', species: 'Pteridophyta' } as any}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: 'Fern' })).toBeInTheDocument()
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest smoke test for Plant detail page
- mark Plant detail smoke tests complete in roadmap
- document the new smoke test in the README

## Testing
- `CI=true npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eaf25e088324809a438ae0d31466