### PR TITLE
test: add smoke test for new plant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 All pages should follow the [style guide](./docs/style-guide.md) to ensure a consistent look and feel across the app.
 
 The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks.
+Basic smoke tests ensure the Add Plant page renders correctly.
 
 The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. Basic smoke tests verify the page renders successfully.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
   - [ ] UI styling
   - [x] Validation
   - [ ] Persistence
-  - [ ] Smoke tests
+  - [x] Smoke tests
 
 - [ ] Revisit New Plant Page (`/app/plants/new`)
   - [ ] Full UI/UX alignment with style guide

--- a/app/app/plants/new/__tests__/NewPlantPage.test.tsx
+++ b/app/app/plants/new/__tests__/NewPlantPage.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import NewPlantPage from '../page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@/components/PlantForm', () => ({
+  __esModule: true,
+  default: ({ submitLabel }: any) => (
+    <form aria-label="plant-form">{submitLabel}</form>
+  ),
+}));
+
+describe('NewPlantPage', () => {
+  it('renders heading and plant form', () => {
+    render(<NewPlantPage />);
+    expect(
+      screen.getByRole('heading', { name: /add plant/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('plant-form')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add smoke test that confirms the New Plant page renders and includes the form
- document new test in README
- mark roadmap task for Add Plant Form smoke tests as complete

## Testing
- `npm test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a4f55b05208324a977b8acfa46c067