### PR TITLE
Add smoke test for new plant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 
 All pages should follow the [style guide](./docs/style-guide.md) to ensure a consistent look and feel across the app.
 
-The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks.
+The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks. A basic smoke test ensures the Add Plant page renders.
 
 The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. Basic smoke tests verify the page renders successfully.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
   - [ ] UI styling
   - [x] Validation
   - [ ] Persistence
-  - [ ] Smoke tests
+  - [x] Smoke tests
 
 - [ ] Revisit New Plant Page (`/app/plants/new`)
   - [ ] Full UI/UX alignment with style guide

--- a/app/app/plants/__tests__/NewPlantPage.test.tsx
+++ b/app/app/plants/__tests__/NewPlantPage.test.tsx
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import NewPlantPage from '../new/page';
+
+jest.mock('@/components/PlantForm', () => ({ __esModule: true, default: () => <div>PlantForm</div> }));
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), back: jest.fn() }) }));
+
+describe('NewPlantPage', () => {
+  it('renders heading and form', () => {
+    render(<NewPlantPage />);
+    expect(screen.getByRole('heading', { level: 1, name: /add plant/i })).toBeInTheDocument();
+    expect(screen.getByText('PlantForm')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add basic smoke test for `/app/plants/new` page
- mark Add Plant form smoke tests as complete in roadmap
- document Add Plant page smoke test in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5786d3483248b357dc00606f794