### PR TITLE
feat: capture pot height in plant form

### DIFF
--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -30,6 +30,7 @@ export default function NewPlantPage() {
           roomId: '',
           species: '',
           pot: '6 in',
+          potHeight: '6 in',
           potMaterial: 'Plastic',
           light: 'Medium',
           indoor: 'Indoor',

--- a/components/EditPlantModal.tsx
+++ b/components/EditPlantModal.tsx
@@ -48,6 +48,7 @@ export default function EditPlantModal({
               roomId: plant.roomId || '',
               species: plant.species || '',
               pot: plant.potSize || '6 in',
+              potHeight: plant.potSize || '6 in',
               potMaterial: plant.potMaterial || 'Plastic',
               light: plant.lightLevel || plant.light || 'Medium',
               indoor: plant.indoor ? 'Indoor' : 'Outdoor',

--- a/components/PlantForm.test.ts
+++ b/components/PlantForm.test.ts
@@ -6,6 +6,7 @@ describe('plantValuesToSubmit', () => {
     roomId: 'room-1',
     species: 'Ficus',
     pot: '10cm',
+    potHeight: '10cm',
     potMaterial: 'Ceramic',
     light: 'Bright',
     indoor: 'Indoor',

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -18,6 +18,7 @@ export type PlantFormValues = {
   roomId: string;
   species: string;
   pot: string;
+  potHeight: string;
   potMaterial: string;
   light: string;
   indoor: 'Indoor' | 'Outdoor';
@@ -39,6 +40,7 @@ export type PlantFormSubmit = {
   roomId: string;
   species?: string;
   potSize: string;
+  potHeight: string;
   potMaterial: string;
   lightLevel: string;
   indoor: boolean;
@@ -68,6 +70,7 @@ export function plantValuesToSubmit(s: PlantFormValues): PlantFormSubmit {
     roomId: s.roomId,
     species: s.species || undefined,
     potSize: s.pot,
+    potHeight: s.potHeight,
     potMaterial: s.potMaterial,
     lightLevel: s.light,
     indoor: s.indoor === 'Indoor',
@@ -259,7 +262,7 @@ export function BasicsFields({
         <p className="hint">Stored locally in Settings → Defaults.</p>
       </Field>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
         <Field label="Pot size" defaulted={defaults?.pot === state.pot}>
           <div className="flex items-center gap-2">
             <Stepper
@@ -281,6 +284,18 @@ export function BasicsFields({
             </button>
           )}
           <p className="hint">Larger pots stay moist longer.</p>
+        </Field>
+        <Field label="Pot height">
+          <div className="flex items-center gap-2">
+            <Stepper
+              value={state.potHeight.replace(' in', '')}
+              onChange={(v) =>
+                setState({ ...state, potHeight: v ? `${v} in` : '' })
+              }
+              min={1}
+            />
+            <span className="text-sm">in</span>
+          </div>
         </Field>
         <Field
           label="Pot material"
@@ -615,7 +630,7 @@ export function CarePlanFields({
 
   useEffect(() => {
     if (!showSuggest) return;
-    if (!state.species || !state.pot) return;
+    if (!state.species || !state.pot || !state.potHeight) return;
 
     const handle = setTimeout(async () => {
       setSuggestError(null);
@@ -625,6 +640,7 @@ export function CarePlanFields({
           name: state.name,
           species: state.species,
           potSize: state.pot,
+          potHeight: state.potHeight,
           potMaterial: state.potMaterial,
           light: state.light,
           indoor: state.indoor === 'Indoor',
@@ -668,6 +684,7 @@ export function CarePlanFields({
   }, [
     state.species,
     state.pot,
+    state.potHeight,
     state.potMaterial,
     state.light,
     state.indoor,

--- a/lib/aiCare.ts
+++ b/lib/aiCare.ts
@@ -4,6 +4,7 @@ export type AiCareParams = {
   name?: string;
   species?: string;
   potSize?: string;
+  potHeight?: string;
   potMaterial?: string;
   light?: string;
   indoor?: boolean;
@@ -27,6 +28,7 @@ export async function suggestCare({
   name = 'Plant',
   species = '',
   potSize = '',
+  potHeight = '',
   potMaterial = '',
   light = '',
   indoor,
@@ -46,6 +48,7 @@ export async function suggestCare({
     `Name: ${name}`,
     `Species: ${species}`,
     `Pot size: ${potSize}`,
+    `Pot height: ${potHeight}`,
     `Pot material: ${potMaterial}`,
   ];
   if (light) parts.push(`Light: ${light}`);


### PR DESCRIPTION
## Summary
- capture pot height in plant form for improved care recommendations
- send pot height to AI care suggestion service
- expose pot height on new and edit plant pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f6d293988324b075ceaef6182214