### PR TITLE
feat: add loading skeleton to plants list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Add Plant form uses a labeled stepper to guide users through Basics, Setup a
 
 The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. Basic smoke tests verify the page renders successfully.
 
-The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically.
+The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically and now shows skeleton cards while plant data loads.
 
 ## Quick Start
 Kay Maria is intended to run in single-user mode by default.

--- a/app/app/plants/PlantsSkeleton.tsx
+++ b/app/app/plants/PlantsSkeleton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function PlantsSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      data-testid="plants-skeleton"
+      className="grid grid-cols-2 gap-3 animate-pulse"
+    >
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-2xl border bg-white shadow-card overflow-hidden"
+        >
+          <div className="h-24 bg-neutral-200" />
+          <div className="p-2 space-y-2">
+            <div className="h-4 w-3/4 bg-neutral-200 rounded" />
+            <div className="h-3 w-1/2 bg-neutral-200 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Fab from "@/components/Fab";
 import { useRouter } from "next/navigation";
 import usePlants from "./usePlants";
+import PlantsSkeleton from "./PlantsSkeleton";
 
 export default function PlantsView() {
   const { plants: items, error: err, isLoading } = usePlants();
@@ -32,9 +33,7 @@ export default function PlantsView() {
             </div>
           )}
 
-          {isLoading && !items && (
-            <div className="text-sm text-neutral-500">Loading…</div>
-          )}
+          {isLoading && !items && <PlantsSkeleton />}
 
           {sortedItems && (
             <div className="grid grid-cols-2 gap-3">

--- a/app/app/plants/__tests__/PlantsView.test.tsx
+++ b/app/app/plants/__tests__/PlantsView.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import PlantsView from '../PlantsView';
+
+jest.mock('../usePlants');
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+const mockUsePlants = require('../usePlants').default as jest.Mock;
+
+describe('PlantsView', () => {
+  it('shows skeleton while loading', () => {
+    mockUsePlants.mockReturnValue({ plants: null, error: null, isLoading: true });
+    render(<PlantsView />);
+    expect(screen.getByTestId('plants-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows plants when loaded', () => {
+    mockUsePlants.mockReturnValue({
+      plants: [{ id: '1', name: 'Fern', room: 'Living' }],
+      error: null,
+      isLoading: false,
+    });
+    render(<PlantsView />);
+    expect(screen.queryByTestId('plants-skeleton')).toBeNull();
+    expect(screen.getByText('Fern')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add animated skeleton cards while plants list loads
- document new plants page loading state

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb25611c8324b82adf4d3565eda4