### PR TITLE
feat: enforce auth for app routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Kay Maria is intended to run in single-user mode by default.
    # open http://localhost:3000/app
    ```
    The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Run it only if you need to wipe existing data.
-   Log in at `http://localhost:3000/login` with a Supabase email/password account. Use the Settings page to sign out.
+   Routes under `/app` now require authentication and redirect to `/login` when no session is present. Log in at `http://localhost:3000/login` with a Supabase email/password account. Use the Settings page to sign out.
 
 ## Post-merge workflow
 After pulling new changes:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
 
 ## Phase 0 – Foundation
 
-- [ ] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
+ - [x] Supabase Auth setup ([#90](https://github.com/osmond/kaymaria/issues/90))
 - [x] Real-time data sync across devices
 - [x] Backend persistence for plant data
 - [x] End-to-end test suite

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  if (process.env.SINGLE_USER_MODE === 'true') {
+    return NextResponse.next();
+  }
+
+  const token = req.cookies.get('sb-access-token');
+  if (!token) {
+    const loginUrl = req.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('redirect', req.nextUrl.pathname + req.nextUrl.search);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/app/:path*'],
+};


### PR DESCRIPTION
## Summary
- add Next.js middleware to protect /app routes
- note auth requirement in README
- mark Supabase auth setup complete in roadmap

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fc8068788324a66e6c187ed4507a