### PR TITLE
feat: align new plant page with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion
 
 All pages should follow the [style guide](./docs/style-guide.md) to ensure a consistent look and feel across the app.
 
-The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks. A Playwright smoke test ensures the Add Plant page renders.
+The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks. A Playwright smoke test ensures the Add Plant page renders. The page now follows the style guide card layout and sets a proper document title for a consistent experience.
 
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,14 +20,14 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
 
 ### 🪴 Plant Management
 
-- [ ] Add Plant Form Polish
-  - [x] UI styling
-  - [x] Validation
-  - [x] Persistence
-  - [x] Smoke tests
+ - [x] Add Plant Form Polish
+   - [x] UI styling
+   - [x] Validation
+   - [x] Persistence
+   - [x] Smoke tests
 
 - [ ] Revisit New Plant Page (`/app/plants/new`)
-  - [ ] Full UI/UX alignment with style guide
+  - [x] Full UI/UX alignment with style guide
   - [ ] Responsive layout check
   - [ ] Accessibility audit
 

--- a/app/app/plants/new/NewPlantClient.tsx
+++ b/app/app/plants/new/NewPlantClient.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import PlantForm, { PlantFormSubmit } from '@/components/PlantForm';
+import { useRouter } from 'next/navigation';
+
+export default function NewPlantClient() {
+  const router = useRouter();
+
+  async function handleSubmit(data: PlantFormSubmit) {
+    const res = await fetch('/api/plants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const created = await res.json();
+    router.push(`/app/plants/${created.id}/created`);
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <main className="p-4">
+      <div className="max-w-xl mx-auto rounded-2xl bg-white shadow-card p-4 md:p-6">
+        <header className="mb-4">
+          <h1 className="text-lg font-display font-semibold">Add Plant</h1>
+        </header>
+        <PlantForm
+          initial={{
+            name: '',
+            roomId: '',
+            species: '',
+            pot: '6 in',
+            potHeight: '6 in',
+            potMaterial: 'Plastic',
+            light: 'Medium',
+            indoor: 'Indoor',
+            drainage: 'ok',
+            soil: '',
+            humidity: '',
+            waterEvery: '7',
+            waterAmount: '500',
+            fertEvery: '30',
+            fertFormula: '',
+            lastWatered: today,
+            lastFertilized: today,
+          }}
+          submitLabel="Add Plant"
+          onSubmit={handleSubmit}
+          onCancel={() => router.back()}
+        />
+      </div>
+    </main>
+  );
+}
+

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -1,54 +1,11 @@
-'use client';
+import type { Metadata } from 'next';
+import NewPlantClient from './NewPlantClient';
 
-import PlantForm, { PlantFormSubmit } from '@/components/PlantForm';
-import { useRouter } from 'next/navigation';
+export const metadata: Metadata = {
+  title: 'Add Plant',
+};
 
 export default function NewPlantPage() {
-  const router = useRouter();
-
-  async function handleSubmit(data: PlantFormSubmit) {
-    const res = await fetch('/api/plants', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const created = await res.json();
-    router.push(`/app/plants/${created.id}/created`);
-  }
-
-  const today = new Date().toISOString().slice(0, 10);
-
-  return (
-    <div className="max-w-xl mx-auto bg-white rounded-2xl shadow-card">
-      <header className="border-b p-6">
-        <h1 className="text-lg font-display font-semibold">Add Plant</h1>
-      </header>
-      <PlantForm
-        initial={{
-          name: '',
-          roomId: '',
-          species: '',
-          pot: '6 in',
-          potHeight: '6 in',
-          potMaterial: 'Plastic',
-          light: 'Medium',
-          indoor: 'Indoor',
-          drainage: 'ok',
-          soil: '',
-          humidity: '',
-          waterEvery: '7',
-          waterAmount: '500',
-          fertEvery: '30',
-          fertFormula: '',
-          lastWatered: today,
-          lastFertilized: today,
-        }}
-        submitLabel="Add Plant"
-        onSubmit={handleSubmit}
-        onCancel={() => router.back()}
-      />
-    </div>
-  );
+  return <NewPlantClient />;
 }
 


### PR DESCRIPTION
## Summary
- style new plant page using card layout and export page metadata
- note the enhancement in README and mark roadmap task complete

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fdf95bb883249256921bf56b8a43