### PR TITLE
feat: sync plant detail tab with url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `/app/plants/new` page now applies the card layout and typography defined in
 
 
 
-The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. It also uses semantic design tokens for background and text colors to stay aligned with the style guide. Basic smoke tests verify the page renders successfully.
+The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. It also uses semantic design tokens for background and text colors to stay aligned with the style guide. The active tab is synced to the URL so deep links open to the correct section and the browser back button restores the previous tab. Basic smoke tests verify the page renders successfully.
 
 The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically and now shows skeleton cards while plant data loads.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,9 +31,9 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
   - [x] Responsive layout check
   - [x] Accessibility audit
 
- - [ ] Plant Detail Page
+- [ ] Plant Detail Page
   - [x] UI styling
-  - [ ] Navigation improvements
+  - [x] Navigation improvements
   - [ ] Loading states
   - [ ] Smoke tests
   - [ ] Visual alignment with style guide

--- a/app/app/plants/__tests__/PlantDetailClient.test.tsx
+++ b/app/app/plants/__tests__/PlantDetailClient.test.tsx
@@ -9,6 +9,7 @@ jest.mock('next/link', () => ({ __esModule: true, default: ({ children }: any) =
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
   useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/plants/1',
 }));
 jest.mock('@/components/EditPlantModal', () => () => null);
 jest.mock('@/components/BottomNav', () => () => null);


### PR DESCRIPTION
## Summary
- sync plant detail tabs with URL query to support deep links and back/forward navigation
- document tab URL syncing in README
- mark roadmap navigation improvements complete

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright browsers/dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a500da37b0832497c656efd0e47221