### PR TITLE
Gracefully handle weather fetch failures

### DIFF
--- a/app/api/plants/[id]/weather/route.ts
+++ b/app/api/plants/[id]/weather/route.ts
@@ -10,10 +10,17 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     }
 
     const url = `https://api.open-meteo.com/v1/forecast?latitude=${plant.latitude}&longitude=${plant.longitude}&current_weather=true`;
-    const r = await fetch(url);
-    if (!r.ok) throw new Error("weather fetch failed");
-    const data = await r.json();
-    return NextResponse.json(data.current_weather ?? {});
+    try {
+      const r = await fetch(url);
+      if (r.ok) {
+        const data = await r.json();
+        return NextResponse.json(data.current_weather ?? {});
+      }
+      console.error(`Open-Meteo responded HTTP ${r.status}`);
+    } catch (err) {
+      console.error("Open-Meteo fetch failed:", err);
+    }
+    return NextResponse.json({});
   } catch (e) {
     console.error("GET /api/plants/[id]/weather failed:", e);
     return NextResponse.json({ error: "server" }, { status: 500 });


### PR DESCRIPTION
## Summary
- Avoid throwing an error when Open‑Meteo weather requests fail
- Return an empty weather payload instead of a 500 response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5088a69cc8324858d5d96d1968f54