### PR TITLE
feat: align plant detail page with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `/app/plants/new` page now applies the card layout and typography defined in
 
 
 
-The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. It also uses semantic design tokens for background and text colors to stay aligned with the style guide. The active tab is synced to the URL so deep links open to the correct section and the browser back button restores the previous tab. Timeline and Notes sections display lightweight placeholders while data loads, and basic smoke tests verify the page renders successfully.
+The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. It also uses semantic design tokens for background and text colors to stay aligned with the style guide, and all sections now use the shared Card component to keep spacing and styling consistent. The active tab is synced to the URL so deep links open to the correct section and the browser back button restores the previous tab. Timeline and Notes sections display lightweight placeholders while data loads, and basic smoke tests verify the page renders successfully.
 
 The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically and now shows skeleton cards while plant data loads.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,12 +31,12 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
   - [x] Responsive layout check
   - [x] Accessibility audit
 
-- [ ] Plant Detail Page
+- [x] Plant Detail Page
   - [x] UI styling
   - [x] Navigation improvements
   - [x] Loading states
   - [x] Smoke tests
-  - [ ] Visual alignment with style guide
+  - [x] Visual alignment with style guide
 
 ---
 

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
  import { ArrowLeft, Droplet, FlaskConical, Sprout, Pencil, MoreVertical } from "lucide-react";
 import BottomNav from '@/components/BottomNav';
 import CareSummary from '@/components/CareSummary';
+import { Card, CardHeader, CardContent, CardTitle, CardDescription } from '@/components/ui/card';
 import type { Plant } from '@prisma/client';
 
 type CareType = "water" | "fertilize" | "repot";
@@ -329,16 +330,16 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
       {/* Content */}
       <main className="flex-1 px-4 pb-28">
         {/* Hero */}
-        <div className="rounded-2xl overflow-hidden border border-border bg-white shadow-card mt-4">
-        <img src={heroPhoto} alt={name} className="w-full aspect-[4/3] object-cover bg-border" />
-          <div className="p-4">
+        <Card className="overflow-hidden mt-4">
+          <img src={heroPhoto} alt={name} className="w-full aspect-[4/3] object-cover bg-border" />
+          <CardContent>
             <h2 className="text-lg font-display font-semibold">{name}</h2>
             <div className="text-sm text-muted">
               {species || "—"}
               {acquired && ` • Acquired ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(acquired)}`}
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
           {careTips.length > 0 && (
             <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
               {careTips.map((t, i) => (
@@ -418,131 +419,137 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
         )}
 
         {tab === "timeline" && (
-          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card">
-            <div className="px-4 py-3 border-b border-border">
-              <div className="text-base font-medium">Timeline</div>
-              <div className="text-xs text-muted">Upcoming &amp; recent care</div>
-            </div>
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle>Timeline</CardTitle>
+              <CardDescription>Upcoming &amp; recent care</CardDescription>
+            </CardHeader>
             {undoInfo && (
-              <div className="px-4 py-2 text-xs bg-green-50 text-green-800 flex justify-between">
+              <div className="px-4 md:px-6 py-2 text-xs bg-green-50 text-green-800 flex justify-between">
                 <span>Task completed.</span>
                 <button onClick={undoTimeline} className="underline">Undo</button>
               </div>
             )}
-            <ul className="text-sm px-4 py-2">
-              {allTasks === null && !err && (
-                <>
-                  {[0, 1, 2].map(i => (
-                    <li key={i} className="py-3 border-b border-border last:border-b-0 flex justify-between items-center animate-pulse">
-                      <span className="h-4 w-1/2 bg-border rounded" />
-                      <span className="h-4 w-10 bg-border rounded" />
-                    </li>
-                  ))}
-                </>
-              )}
-              {err && <li className="py-3 text-red-600">{err}</li>}
-              {!err && allTasks !== null && plantTasks.length === 0 && <li className="py-3 text-muted">No tasks yet</li>}
-              {!err && allTasks !== null && plantTasks.map(t => (
-                <li key={t.id} className="py-3 border-b border-border last:border-b-0 flex justify-between items-center">
-                  <span>
-                    {iconFor(t.type)} {t.type === "water" ? "Water" : t.type === "fertilize" ? "Fertilize" : "Repot"} — {new Intl.DateTimeFormat(undefined, { month:"short", day:"numeric" }).format(new Date(t.dueAt))}
-                    {(() => {
-                      const d = new Date(t.dueAt); const today = new Date();
-                      const diff = Math.round((new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() - new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime())/86400000);
-                      return diff > 0 ? ` (In ${diff}d)` : diff === 0 ? " (Today)" : "";
-                    })()}
-                  </span>
-                  <button onClick={() => markTimelineDone(t)} className="text-xs text-blue-600">Done</button>
-                </li>
-              ))}
-            </ul>
-          </section>
+            <CardContent className="pt-2">
+              <ul className="text-sm">
+                {allTasks === null && !err && (
+                  <>
+                    {[0, 1, 2].map(i => (
+                      <li key={i} className="py-3 border-b border-border last:border-b-0 flex justify-between items-center animate-pulse">
+                        <span className="h-4 w-1/2 bg-border rounded" />
+                        <span className="h-4 w-10 bg-border rounded" />
+                      </li>
+                    ))}
+                  </>
+                )}
+                {err && <li className="py-3 text-red-600">{err}</li>}
+                {!err && allTasks !== null && plantTasks.length === 0 && <li className="py-3 text-muted">No tasks yet</li>}
+                {!err && allTasks !== null && plantTasks.map(t => (
+                  <li key={t.id} className="py-3 border-b border-border last:border-b-0 flex justify-between items-center">
+                    <span>
+                      {iconFor(t.type)} {t.type === "water" ? "Water" : t.type === "fertilize" ? "Fertilize" : "Repot"} — {new Intl.DateTimeFormat(undefined, { month:"short", day:"numeric" }).format(new Date(t.dueAt))}
+                      {(() => {
+                        const d = new Date(t.dueAt); const today = new Date();
+                        const diff = Math.round((new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() - new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime())/86400000);
+                        return diff > 0 ? ` (In ${diff}d)` : diff === 0 ? " (Today)" : "";
+                      })()}
+                    </span>
+                    <button onClick={() => markTimelineDone(t)} className="text-xs text-blue-600">Done</button>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         )}
 
         {tab === "notes" && (
-          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card p-4 text-sm">
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                addNote();
-              }}
-            >
-              <textarea
-                value={noteText}
-                onChange={(e) => setNoteText(e.target.value)}
-                placeholder="Write a note..."
-                className="w-full border border-border rounded p-2 text-sm"
-              />
-              <div className="text-right mt-2">
-                <button type="submit" className="px-3 py-1 rounded bg-primary text-primary-foreground text-xs">
-                  Add Note
-                </button>
-              </div>
-            </form>
-            <ul className="mt-4 space-y-3">
-              {notes === null && <li className="h-4 bg-border rounded animate-pulse" />}
-              {notes !== null && notes.length === 0 && <li className="text-muted">No notes yet</li>}
-              {notes?.map((n) => (
-                <li key={n.id} className="border-t border-border pt-2 first:border-t-0 first:pt-0">
-                  <div>{n.note}</div>
-                  <div className="text-xs text-muted">
-                    {new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(new Date(n.createdAt))}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
+          <Card className="mt-4 text-sm">
+            <CardContent>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  addNote();
+                }}
+              >
+                <textarea
+                  value={noteText}
+                  onChange={(e) => setNoteText(e.target.value)}
+                  placeholder="Write a note..."
+                  className="w-full border border-border rounded p-2 text-sm"
+                />
+                <div className="text-right mt-2">
+                  <button type="submit" className="px-3 py-1 rounded bg-primary text-primary-foreground text-xs">
+                    Add Note
+                  </button>
+                </div>
+              </form>
+              <ul className="mt-4 space-y-3">
+                {notes === null && <li className="h-4 bg-border rounded animate-pulse" />}
+                {notes !== null && notes.length === 0 && <li className="text-muted">No notes yet</li>}
+                {notes?.map((n) => (
+                  <li key={n.id} className="border-t border-border pt-2 first:border-t-0 first:pt-0">
+                    <div>{n.note}</div>
+                    <div className="text-xs text-muted">
+                      {new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(new Date(n.createdAt))}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         )}
 
         {tab === "photos" && (
-          <section className="mt-4 rounded-2xl border border-border bg-white shadow-card p-4">
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                addPhotoFile();
-                e.currentTarget.reset();
-              }}
-              className="flex gap-2 mb-4"
-            >
-              <input
-                type="file"
-                accept="image/*"
-                capture="environment"
-                onChange={(e) => setNewPhotoFile(e.target.files?.[0] || null)}
-                className="flex-1 border border-border rounded p-2 text-sm"
-              />
-              <button
-                type="submit"
-                className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm"
-                disabled={!newPhotoFile}
+          <Card className="mt-4">
+            <CardContent>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  addPhotoFile();
+                  e.currentTarget.reset();
+                }}
+                className="flex gap-2 mb-4"
               >
-                Add
-              </button>
-            </form>
-            {photos.length > 0 ? (
-              <div className="grid grid-cols-3 gap-2">
-                {photos.map((src, i) => (
-                  <div key={i} className="relative">
-                    <img
-                      src={src}
-                      alt={`${plantState.name} photo ${i + 1}`}
-                      className="w-full h-24 object-cover rounded"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removePhotoUrl(src)}
-                      className="absolute top-1 right-1 text-xs bg-white/80 rounded-full px-1"
-                      aria-label="Remove photo"
-                    >
-                      ×
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="text-sm text-muted text-center">No photos yet</div>
-            )}
-          </section>
+                <input
+                  type="file"
+                  accept="image/*"
+                  capture="environment"
+                  onChange={(e) => setNewPhotoFile(e.target.files?.[0] || null)}
+                  className="flex-1 border border-border rounded p-2 text-sm"
+                />
+                <button
+                  type="submit"
+                  className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm"
+                  disabled={!newPhotoFile}
+                >
+                  Add
+                </button>
+              </form>
+              {photos.length > 0 ? (
+                <div className="grid grid-cols-3 gap-2">
+                  {photos.map((src, i) => (
+                    <div key={i} className="relative">
+                      <img
+                        src={src}
+                        alt={`${plantState.name} photo ${i + 1}`}
+                        className="w-full h-24 object-cover rounded"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removePhotoUrl(src)}
+                        className="absolute top-1 right-1 text-xs bg-white/80 rounded-full px-1"
+                        aria-label="Remove photo"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-muted text-center">No photos yet</div>
+              )}
+            </CardContent>
+          </Card>
         )}
 
         <div className="h-16" />
@@ -556,9 +563,11 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-border bg-white p-3 shadow-card">
-      <div className="text-xs text-muted">{label}</div>
-      <div className="text-base font-medium">{value}</div>
-    </div>
+    <Card>
+      <CardContent>
+        <div className="text-xs text-muted">{label}</div>
+        <div className="text-base font-medium">{value}</div>
+      </CardContent>
+    </Card>
   );
 }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -14,7 +14,7 @@ export function Card({ className = "", ...props }: DivProps) {
   );
 }
 export function CardHeader({ className = "", ...props }: DivProps) {
-  return <div className={`p-4 ${className}`} {...props} />;
+  return <div className={`p-4 md:p-6 ${className}`} {...props} />;
 }
 export function CardTitle({ className = "", ...props }: HProps) {
   return <h3 className={`text-base font-medium ${className}`} {...props} />;
@@ -23,5 +23,5 @@ export function CardDescription({ className = "", ...props }: PProps) {
   return <p className={`text-sm text-muted dark:text-neutral-400 ${className}`} {...props} />;
 }
 export function CardContent({ className = "", ...props }: DivProps) {
-  return <div className={`p-4 ${className}`} {...props} />;
+  return <div className={`p-4 md:p-6 ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary
- wrap plant detail sections with shared Card component to match style guide spacing
- add responsive padding to Card primitives
- mark Plant Detail Page roadmap task complete and document the update

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a508ec8c8c8324a70fdf2ff3d43515