### PR TITLE
feat: add events POST handler

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -37,3 +37,89 @@ export async function GET(req: NextRequest) {
   }));
   return NextResponse.json(events);
 }
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createRouteHandlerClient();
+    const userRes = await getUserId(supabase);
+    if ("error" in userRes) {
+      if (userRes.error === "unauthorized") {
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      }
+      return NextResponse.json({ error: "misconfigured server" }, { status: 500 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const plantId = body.plantId;
+    const type = String(body.type || "").toLowerCase();
+    const validTypes = ["water", "fertilize", "repot"];
+    if (!plantId || !validTypes.includes(type)) {
+      return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+    }
+
+    const eventAt = body.at
+      ? new Date(body.at).toISOString()
+      : new Date().toISOString();
+    const nextDue = new Date(eventAt);
+    nextDue.setDate(nextDue.getDate() + 1);
+
+    const { data: existing, error: fetchError } = await supabase
+      .from("tasks")
+      .select("id")
+      .eq("user_id", userRes.userId)
+      .eq("plant_id", plantId)
+      .eq("type", type)
+      .maybeSingle();
+    if (fetchError) {
+      console.error("POST /api/events fetch failed:", fetchError);
+      return NextResponse.json({ error: "server" }, { status: 500 });
+    }
+
+    let record;
+    if (existing) {
+      const { data, error } = await supabase
+        .from("tasks")
+        .update({
+          last_done_at: eventAt,
+          due_at: nextDue.toISOString(),
+        })
+        .eq("id", existing.id)
+        .select("id, type, plant:plants(id, name)")
+        .single();
+      if (error) {
+        console.error("POST /api/events update failed:", error);
+        return NextResponse.json({ error: "server" }, { status: 500 });
+      }
+      record = data;
+    } else {
+      const { data, error } = await supabase
+        .from("tasks")
+        .insert({
+          user_id: userRes.userId,
+          plant_id: plantId,
+          type,
+          due_at: nextDue.toISOString(),
+          last_done_at: eventAt,
+        })
+        .select("id, type, plant:plants(id, name)")
+        .single();
+      if (error) {
+        console.error("POST /api/events insert failed:", error);
+        return NextResponse.json({ error: "server" }, { status: 500 });
+      }
+      record = data;
+    }
+
+    const event = {
+      id: record.id,
+      plantId: record.plant?.id ?? plantId,
+      plantName: record.plant?.name ?? "",
+      type: record.type,
+      at: eventAt,
+    };
+    return NextResponse.json(event, { status: existing ? 200 : 201 });
+  } catch (e) {
+    console.error("POST /api/events failed:", e);
+    return NextResponse.json({ error: "server" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add POST route for recording plant care events
- validate incoming event payload and persist via Supabase
- improve error handling and logging around event persistence

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a50b7e085c832488c479793c4d875d