### PR TITLE
feat(plants): add empty state to plants page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `/app/plants/new` page now applies the card layout and typography defined in
 The Plant detail page shows a skeleton screen while loading, includes a back link to the Plants list for smoother navigation, and now displays its hero photo with a consistent aspect ratio for a more polished layout. It also uses semantic design tokens for background and text colors to stay aligned with the style guide, and all sections now use the shared Card component to keep spacing and styling consistent. The active tab is synced to the URL so deep links open to the correct section and the browser back button restores the previous tab. Timeline and Notes sections display lightweight placeholders while data loads, and basic smoke tests verify the page renders successfully.
 
 
-The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically and now shows skeleton cards while plant data loads.
+The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet.
 
 Authenticated sessions also use a Supabase-backed `/api/sync` endpoint to persist and fetch user data across devices.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
 
 ## Phase 2 – Core Pages UX Polish
 
-- [ ] `/app/plants` (All Plants / Rooms)
+- [x] `/app/plants` (All Plants / Rooms)
 - [ ] `/app/today` (Daily Task View)
 - [ ] `/app/timeline` (Plant History)
 - [ ] `/app/insights` (Analytics)

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -4,6 +4,7 @@ import Fab from "@/components/Fab";
 import { useRouter } from "next/navigation";
 import usePlants from "./usePlants";
 import PlantsSkeleton from "./PlantsSkeleton";
+import { Card, CardContent } from "@/components/ui/card";
 
 export default function PlantsView() {
   const { plants: items, error: err, isLoading } = usePlants();
@@ -21,35 +22,43 @@ export default function PlantsView() {
       <section className="mt-4 space-y-6">
         <div>
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-sm font-display font-medium text-neutral-600">My Plants</h2>
-            <span className="text-xs text-neutral-500">
+            <h2 className="text-sm font-display font-medium text-foreground">My Plants</h2>
+            <span className="text-xs text-muted">
               {items?.length ?? 0} total
             </span>
           </div>
 
           {err && (
-            <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-red-600">
+            <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-destructive">
               {err}
             </div>
           )}
 
           {isLoading && !items && <PlantsSkeleton />}
 
-          {sortedItems && (
+          {sortedItems && sortedItems.length > 0 && (
             <div className="grid grid-cols-2 gap-3">
               {sortedItems.map((p) => (
                 <Link key={p.id} href={`/app/plants/${p.id}`} className="text-left">
-                  <div className="rounded-2xl border bg-white shadow-card overflow-hidden">
-                    <div className="h-24 bg-neutral-100" />
-                    <div className="p-2">
+                  <Card className="overflow-hidden">
+                    <div className="h-24 bg-muted" />
+                    <CardContent className="p-2">
                       <div className="text-sm font-medium truncate">{p.name}</div>
-                      <div className="text-xs text-neutral-500">
+                      <div className="text-xs text-muted">
                         {p.room ? `Room: ${p.room}` : "—"}
                       </div>
-                    </div>
-                  </div>
+                    </CardContent>
+                  </Card>
                 </Link>
               ))}
+            </div>
+          )}
+
+          {sortedItems && sortedItems.length === 0 && !isLoading && !err && (
+            <div className="rounded-2xl border bg-white shadow-card p-6 text-center">
+              <p className="text-sm text-muted">
+                No plants yet. Add your first to start tending 🌿
+              </p>
             </div>
           )}
         </div>

--- a/app/app/plants/__tests__/PlantsView.test.tsx
+++ b/app/app/plants/__tests__/PlantsView.test.tsx
@@ -26,4 +26,12 @@ describe('PlantsView', () => {
     expect(screen.queryByTestId('plants-skeleton')).toBeNull();
     expect(screen.getByText('Fern')).toBeInTheDocument();
   });
+
+  it('shows empty state when no plants', () => {
+    mockUsePlants.mockReturnValue({ plants: [], error: null, isLoading: false });
+    render(<PlantsView />);
+    expect(
+      screen.getByText('No plants yet. Add your first to start tending 🌿')
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- show plant cards using the shared Card component and design tokens
- display an empty state on My Plants when no plants exist
- document new behavior and mark the plants page roadmap item complete

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a50b37b1cc8324918f2335fe2f6dc1