### PR TITLE
Handle Esc to close plant detail menu

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -164,13 +164,22 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
   }, [id, plantState.latitude, plantState.longitude]);
 
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const clickHandler = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setMenuOpen(false);
       }
     };
-    document.addEventListener("click", handler);
-    return () => document.removeEventListener("click", handler);
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("click", clickHandler);
+    document.addEventListener("keydown", keyHandler);
+    return () => {
+      document.removeEventListener("click", clickHandler);
+      document.removeEventListener("keydown", keyHandler);
+    };
   }, []);
 
 

--- a/app/app/plants/__tests__/PlantDetailClient.test.tsx
+++ b/app/app/plants/__tests__/PlantDetailClient.test.tsx
@@ -3,6 +3,7 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import PlantDetailClient from '../[id]/PlantDetailClient';
 
 jest.mock('next/link', () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }));
@@ -42,6 +43,26 @@ describe('PlantDetailClient', () => {
     await waitFor(() =>
       expect(screen.getByRole('heading', { level: 1, name: 'Fern' })).toBeInTheDocument()
     );
+  });
+
+  it('closes menu when Escape is pressed', async () => {
+    render(
+      <PlantDetailClient
+        plant={{ id: '1', userId: 'u1', name: 'Fern', species: 'Pteridophyta' } as any}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: 'More options' }));
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByText('Edit')).not.toBeInTheDocument());
   });
 });
 


### PR DESCRIPTION
## Summary
- Close plant detail menu when clicking outside or pressing Escape
- Add unit test for Escape key closing behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50ddb21d08324ad6decf14446a469