### PR TITLE
feat: polish insights page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The Today page lists all care tasks due today, grouped by plant with filters for
 
 The Timeline page shows recent care events with filters for plant and event type, supports infinite scroll, and displays skeleton placeholders while loading.
 
+The Insights page visualizes completed and overdue tasks and new plants over a selectable date range with summary cards and a line chart.
+
 The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet.
 
 Authenticated sessions also use a Supabase-backed `/api/sync` endpoint to persist and fetch user data across devices.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,8 +45,8 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
  - [x] `/app/plants` (All Plants / Rooms)
 - [x] `/app/today` (Daily Task View)
 - [x] `/app/timeline` (Plant History)
-- [ ] `/app/insights` (Analytics)
-- [ ] `/app/settings` (App Preferences)
+ - [x] `/app/insights` (Analytics)
+ - [ ] `/app/settings` (App Preferences)
 
 For **each page**, ensure:
   - [ ] Layout hierarchy matches visual system

--- a/app/app/insights/InsightsView.tsx
+++ b/app/app/insights/InsightsView.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState } from "react";
 import InsightsSkeleton from "./InsightsSkeleton";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -89,12 +92,12 @@ export default function InsightsView() {
   return (
     <>
       <section className="mt-4 space-y-6">
-        <h2 className="text-sm font-display font-medium text-neutral-600">Insights</h2>
+        <h2 className="text-sm font-display font-medium text-foreground">Insights</h2>
 
         {err && (
-          <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-red-600">
+          <Card className="p-4 text-sm text-destructive">
             {err}
-          </div>
+          </Card>
         )}
 
         {!data && !err && <InsightsSkeleton />}
@@ -102,40 +105,52 @@ export default function InsightsView() {
         {data && (
           <>
             <div className="flex gap-2">
-              <label className="text-sm">
+              <Label className="flex items-center gap-1">
                 Start:
-                <input
+                <Input
                   type="date"
                   value={start}
                   onChange={(e) => setStart(e.target.value)}
-                  className="ml-1 rounded border px-1"
+                  className="w-auto"
                 />
-              </label>
-              <label className="text-sm">
+              </Label>
+              <Label className="flex items-center gap-1">
                 End:
-                <input
+                <Input
                   type="date"
                   value={end}
                   onChange={(e) => setEnd(e.target.value)}
-                  className="ml-1 rounded border px-1"
+                  className="w-auto"
                 />
-              </label>
+              </Label>
             </div>
             <div className="grid grid-cols-3 gap-3">
-              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
-                <div className="text-sm text-neutral-500">Completed Tasks</div>
-                <div className="text-2xl font-bold">{totalCompletedTasks}</div>
-              </div>
-              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
-                <div className="text-sm text-neutral-500">Overdue Tasks</div>
-                <div className="text-2xl font-bold">{totalOverdueTasks}</div>
-              </div>
-              <div className="rounded-2xl border bg-white shadow-card p-4 text-center">
-                <div className="text-sm text-neutral-500">New Plants</div>
-                <div className="text-2xl font-bold">{totalNewPlants}</div>
-              </div>
+              <Card className="text-center">
+                <CardHeader className="space-y-1">
+                  <CardDescription>Completed Tasks</CardDescription>
+                  <CardTitle className="text-2xl font-bold">
+                    {totalCompletedTasks}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+              <Card className="text-center">
+                <CardHeader className="space-y-1">
+                  <CardDescription>Overdue Tasks</CardDescription>
+                  <CardTitle className="text-2xl font-bold">
+                    {totalOverdueTasks}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+              <Card className="text-center">
+                <CardHeader className="space-y-1">
+                  <CardDescription>New Plants</CardDescription>
+                  <CardTitle className="text-2xl font-bold">
+                    {totalNewPlants}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
             </div>
-            <div className="rounded-2xl border bg-white shadow-card p-4">
+            <Card className="p-4">
               <div className="h-48">
                 <Line
                   data={chartData}
@@ -145,7 +160,7 @@ export default function InsightsView() {
                   }}
                 />
               </div>
-            </div>
+            </Card>
           </>
         )}
       </section>


### PR DESCRIPTION
## Summary
- style Insights page with shared Card, Label, and Input components for consistent tokens
- document Insights analytics view in README
- mark /app/insights page as complete in roadmap

## Testing
- `npm test` *(fails: Pencil is not defined in PlantDetailClient.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a50f891bd08324b8ff466d2b99023a