### PR TITLE
Add insights e2e test and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The Today page lists all care tasks due today, grouped by plant with filters for
 
 The Timeline page shows recent care events with filters for plant and event type, supports infinite scroll, and displays skeleton placeholders while loading.
 
+The Insights page charts completed tasks, overdue tasks, and newly added plants over a selectable date range to highlight recent activity.
+
 The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet.
 
 Authenticated sessions also use a Supabase-backed `/api/sync` endpoint to persist and fetch user data across devices.
@@ -72,7 +74,7 @@ After pulling new changes:
 ## Testing
 - Unit tests: `npm test`
 - Manual scenarios live in [docs/manual-test-cases.md](./docs/manual-test-cases.md)
-- End-to-end tests: `npm run test:e2e` (starts the Next.js dev server and runs Playwright smoke tests, including the Add Plant, Plant Detail, and Timeline pages)
+- End-to-end tests: `npm run test:e2e` (starts the Next.js dev server and runs Playwright smoke tests, including the Add Plant, Plant Detail, Timeline, and Insights pages)
 
 ## Project Structure
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
  - [x] `/app/plants` (All Plants / Rooms)
 - [x] `/app/today` (Daily Task View)
 - [x] `/app/timeline` (Plant History)
-- [ ] `/app/insights` (Analytics)
+- [x] `/app/insights` (Analytics)
 - [ ] `/app/settings` (App Preferences)
 
 For **each page**, ensure:

--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
  import { useEffect, useMemo, useState, useRef } from "react";
  import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ArrowLeft, Droplet, FlaskConical, Sprout, MoreVertical } from "lucide-react";
+import { ArrowLeft, Droplet, FlaskConical, Sprout, MoreVertical, Pencil } from "lucide-react";
 import BottomNav from '@/components/BottomNav';
 import CareSummary from '@/components/CareSummary';
 import { Card, CardHeader, CardContent, CardTitle, CardDescription } from '@/components/ui/card';

--- a/e2e/insights.spec.ts
+++ b/e2e/insights.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('insights page renders', async ({ page }) => {
+  await page.goto('/app/insights');
+  await expect(page.getByRole('heading', { name: 'Insights' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke test for Insights page
- document Insights analytics in README and mark roadmap item complete
- fix missing Pencil icon import in plant detail view

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; suggested running `npx playwright install`, but download returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a50fa44dd8832495b368e41592fe85