### PR TITLE
feat: align plants page layout with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Timeline page shows recent care events with filters for plant and event type
 
 The Insights page visualizes completed and overdue tasks and new plants over a selectable date range with summary cards and a line chart.
 
-The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet.
+The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet. It now uses the shared page header so its layout hierarchy matches the visual system used across the app.
 
 Authenticated sessions also use a Supabase-backed `/api/sync` endpoint to persist and fetch user data across devices.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
  - [x] `/app/settings` (App Preferences)
 
 For **each page**, ensure:
-  - [ ] Layout hierarchy matches visual system
+  - [x] Layout hierarchy matches visual system (Plants page)
   - [ ] Typography uses only approved fonts and scales
   - [ ] Buttons, labels, and states align with design tokens
   - [ ] Responsive layout verified

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -5,6 +5,25 @@ import { useRouter } from "next/navigation";
 import usePlants from "./usePlants";
 import PlantsSkeleton from "./PlantsSkeleton";
 import { Card, CardContent } from "@/components/ui/card";
+import { useEffect, useState } from "react";
+
+function ClientDate() {
+  const [text, setText] = useState("");
+  useEffect(() => {
+    setText(
+      new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      }).format(new Date()),
+    );
+  }, []);
+  return (
+    <span suppressHydrationWarning className="text-sm text-neutral-500">
+      {text}
+    </span>
+  );
+}
 
 export default function PlantsView() {
   const { plants: items, error: err, isLoading } = usePlants();
@@ -18,52 +37,63 @@ export default function PlantsView() {
     }) ?? null;
 
   return (
-    <>
-      <section className="mt-4 space-y-6">
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <h2 className="text-sm font-display font-medium text-foreground">My Plants</h2>
-            <span className="text-xs text-muted">
-              {items?.length ?? 0} total
-            </span>
-          </div>
-
-          {err && (
-            <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-destructive">
-              {err}
-            </div>
-          )}
-
-          {isLoading && !items && <PlantsSkeleton />}
-
-          {sortedItems && sortedItems.length > 0 && (
-            <div className="grid grid-cols-2 gap-3">
-              {sortedItems.map((p) => (
-                <Link key={p.id} href={`/app/plants/${p.id}`} className="text-left">
-                  <Card className="overflow-hidden">
-                    <div className="h-24 bg-muted" />
-                    <CardContent className="p-2">
-                      <div className="text-sm font-medium truncate">{p.name}</div>
-                      <div className="text-xs text-muted">
-                        {p.room ? `Room: ${p.room}` : "—"}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </Link>
-              ))}
-            </div>
-          )}
-
-          {sortedItems && sortedItems.length === 0 && !isLoading && !err && (
-            <div className="rounded-2xl border bg-white shadow-card p-6 text-center">
-              <p className="text-sm text-muted">
-                No plants yet. Add your first to start tending 🌿
-              </p>
-            </div>
-          )}
+    <div className="min-h-[100dvh] flex flex-col w-full">
+      <header
+        className="px-4 pb-2 sticky top-0 z-20 bg-gradient-to-b from-white/90 to-neutral-50/60 backdrop-blur border-b"
+        style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}
+      >
+        <div className="flex items-baseline justify-between w-full">
+          <h1 className="text-xl font-display font-semibold">Plants</h1>
+          <ClientDate />
         </div>
-      </section>
+      </header>
+      <main className="flex-1 px-4 pb-28">
+        <section className="mt-4 space-y-6">
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-base font-medium text-foreground">My Plants</h2>
+              <span className="text-sm text-muted">
+                {items?.length ?? 0} total
+              </span>
+            </div>
+
+            {err && (
+              <div className="rounded-2xl border bg-white shadow-card p-4 text-sm text-destructive">
+                {err}
+              </div>
+            )}
+
+            {isLoading && !items && <PlantsSkeleton />}
+
+            {sortedItems && sortedItems.length > 0 && (
+              <div className="grid grid-cols-2 gap-3">
+                {sortedItems.map((p) => (
+                  <Link key={p.id} href={`/app/plants/${p.id}`} className="text-left">
+                    <Card className="overflow-hidden">
+                      <div className="h-24 bg-muted" />
+                      <CardContent className="p-2">
+                        <div className="text-sm font-medium truncate">{p.name}</div>
+                        <div className="text-xs text-muted">
+                          {p.room ? `Room: ${p.room}` : "—"}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            )}
+
+            {sortedItems && sortedItems.length === 0 && !isLoading && !err && (
+              <div className="rounded-2xl border bg-white shadow-card p-6 text-center">
+                <p className="text-sm text-muted">
+                  No plants yet. Add your first to start tending 🌿
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      </main>
       <Fab onClick={() => router.push("/app/plants/new")} />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add shared header to plants page to follow visual hierarchy
- mark roadmap item for layout hierarchy and document change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a514a53d8c8324868c68a5e91a0de5