### PR TITLE
feat: align buttons and labels with design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository hosts **Kay Maria**, a Next.js + TypeScript plant care companion with real-time task and plant syncing across devices. The goal of this README is to give contributors (like me) a fast reference for building, testing and exploring the project.
 
-All pages should follow the [style guide](./docs/style-guide.md) to ensure a consistent look and feel across the app. Headings use the Cabinet Grotesk typeface while body text uses Inter; both fonts load from Google Fonts and are applied via Tailwind classes.
+All pages should follow the [style guide](./docs/style-guide.md) to ensure a consistent look and feel across the app. Headings use the Cabinet Grotesk typeface while body text uses Inter; both fonts load from Google Fonts and are applied via Tailwind classes. Buttons and form labels rely on semantic design tokens for their colors and state styles.
 
 The Add Plant form uses a labeled stepper to guide users through Basics, Setup and Care plan sections. Form fields include validation for required entries, numeric values, and latitude/longitude ranges. Submitting the form now persists the plant to the backend and pre-creates care tasks. A Playwright smoke test ensures the Add Plant page renders.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ This roadmap outlines the next development milestones for the **Kay Maria** plan
 For **each page**, ensure:
   - [x] Layout hierarchy matches visual system (Plants page)
   - [x] Typography uses only approved fonts and scales
-  - [ ] Buttons, labels, and states align with design tokens
+  - [x] Buttons, labels, and states align with design tokens
   - [ ] Responsive layout verified
   - [ ] Regressions checked
 

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -940,7 +940,7 @@ export function SettingsView() {
                 Export CSV
               </Button>
               <Button
-                variant="default"
+                variant="primary"
                 size="sm"
                 onClick={() => fileInputRef.current?.click()}
               >

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,7 +1,13 @@
 "use client";
 import * as React from "react";
 
-type Variant = "default" | "secondary" | "ghost";
+type Variant =
+  | "primary"
+  | "secondary"
+  | "ghost"
+  | "destructive"
+  | "success"
+  | "warning";
 type Size = "default" | "sm" | "icon";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -10,17 +16,23 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { className = "", variant = "default", size = "default", ...props },
+  { className = "", variant = "primary", size = "default", ...props },
   ref
 ) {
   const base =
     "inline-flex items-center justify-center rounded-xl shadow-md font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/50 disabled:opacity-50 disabled:pointer-events-none";
   const byVariant =
     variant === "secondary"
-      ? "bg-secondary text-foreground hover:bg-secondary/80"
+      ? "bg-secondary text-secondary-foreground hover:bg-secondary/80"
       : variant === "ghost"
       ? "bg-transparent text-foreground hover:bg-background"
-      : "bg-primary text-white hover:bg-primary/90";
+      : variant === "destructive"
+      ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      : variant === "success"
+      ? "bg-success text-success-foreground hover:bg-success/90"
+      : variant === "warning"
+      ? "bg-warning text-warning-foreground hover:bg-warning/90"
+      : "bg-primary text-primary-foreground hover:bg-primary/90";
   const bySize =
     size === "sm" ? "h-8 px-3 text-sm" : size === "icon" ? "h-10 w-10 p-0" : "h-10 px-4";
   return <button ref={ref} className={`${base} ${byVariant} ${bySize} ${className}`} {...props} />;

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,9 +1,13 @@
 "use client";
 import * as React from "react";
 
-export function Label({
-  className = "",
-  ...props
-}: React.LabelHTMLAttributes<HTMLLabelElement>) {
-  return <label className={`text-sm font-medium ${className}`} {...props} />;
+type Variant = "default" | "muted";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  variant?: Variant;
+}
+
+export function Label({ className = "", variant = "default", ...props }: LabelProps) {
+  const color = variant === "muted" ? "text-muted" : "text-foreground";
+  return <label className={`text-sm font-medium ${color} ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary
- expand Button component with semantic variants using design tokens
- add variant support to Label component and default to design tokens
- document design token usage and check off roadmap item

## Testing
- `npm test`
- `npm run test:e2e` *(fails: page.goto cannot navigate to invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a65a7e48324ad58f7fec1682775