### PR TITLE
feat: make plants view responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Timeline page shows recent care events with filters for plant and event type
 
 The Insights page visualizes completed and overdue tasks and new plants over a selectable date range with summary cards and a line chart.
 
-The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet. It now uses the shared page header so its layout hierarchy matches the visual system used across the app.
+The My Plants view listens to Supabase real-time updates so changes from other sessions appear automatically, shows skeleton cards while plant data loads, and displays a friendly empty state when you haven't added any plants yet. It now uses the shared page header so its layout hierarchy matches the visual system used across the app. The plant list renders in a single column on small screens and switches to a two-column grid on larger viewports for better responsiveness.
 
 Authenticated sessions also use a Supabase-backed `/api/sync` endpoint to persist and fetch user data across devices.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,7 @@ For **each page**, ensure:
 **This pass should include final QA against the [style guide](https://github.com/osmond/kaymaria/blob/main/docs/style-guide.md).**
 
 - [ ] Revisit and polish the following views:
-  - [ ] Plants page (`/app/plants`)
+  - [x] Plants page (`/app/plants`)
   - [ ] New Plant page (`/app/plants/new`)
   - [ ] Today page (`/app/today`)
   - [ ] Timeline page (`/app/timeline`)

--- a/app/app/plants/PlantsView.tsx
+++ b/app/app/plants/PlantsView.tsx
@@ -66,7 +66,10 @@ export default function PlantsView() {
             {isLoading && !items && <PlantsSkeleton />}
 
             {sortedItems && sortedItems.length > 0 && (
-              <div className="grid grid-cols-2 gap-3">
+              <div
+                className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+                data-testid="plants-grid"
+              >
                 {sortedItems.map((p) => (
                   <Link key={p.id} href={`/app/plants/${p.id}`} className="text-left">
                     <Card className="overflow-hidden">

--- a/app/app/plants/__tests__/PlantsView.test.tsx
+++ b/app/app/plants/__tests__/PlantsView.test.tsx
@@ -27,6 +27,18 @@ describe('PlantsView', () => {
     expect(screen.getByText('Fern')).toBeInTheDocument();
   });
 
+  it('uses a responsive grid layout', () => {
+    mockUsePlants.mockReturnValue({
+      plants: [{ id: '1', name: 'Fern', room: 'Living' }],
+      error: null,
+      isLoading: false,
+    });
+    render(<PlantsView />);
+    const grid = screen.getByTestId('plants-grid');
+    expect(grid).toHaveClass('grid-cols-1');
+    expect(grid).toHaveClass('sm:grid-cols-2');
+  });
+
   it('shows empty state when no plants', () => {
     mockUsePlants.mockReturnValue({ plants: [], error: null, isLoading: false });
     render(<PlantsView />);


### PR DESCRIPTION
## Summary
- make plant list responsive with single-column mobile grid
- mark roadmap plants page as polished
- document new responsive layout in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a51d8b2ca88324862c6bb1e82a9d5e