### PR TITLE
refactor: rename rules field to plan

### DIFF
--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -26,10 +26,10 @@ export async function PATCH(req: Request, { params }: Params) {
   try {
     const { id } = await params;
     const body = await req.json().catch(() => ({}));
-    const { rules, ...rest } = body;
+    const { plan, ...rest } = body;
     const updated = await updatePlant(id, {
       ...rest,
-      ...(rules ? { carePlan: rules } : {}),
+      ...(plan ? { carePlan: plan } : {}),
     });
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);

--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -792,7 +792,7 @@ export function SettingsView() {
       lastFertilizedAt: v.lastFertilized
         ? new Date(v.lastFertilized).toISOString()
         : undefined,
-      rules: [
+      plan: [
         {
           type: "water" as const,
           intervalDays: Number(v.waterEvery),

--- a/components/PlantForm.test.ts
+++ b/components/PlantForm.test.ts
@@ -26,6 +26,14 @@ describe('plantValuesToSubmit', () => {
     expect(result.createTasks).toBe(true);
   });
 
+  it('builds a default plan', () => {
+    const result = plantValuesToSubmit(base);
+    expect(result.plan).toEqual([
+      { type: 'water', intervalDays: 7, amountMl: 500 },
+      { type: 'fertilize', intervalDays: 30, formula: '10-10-10' },
+    ]);
+  });
+
   it('parses valid coordinates', () => {
     const result = plantValuesToSubmit({ ...base, lat: '45', lon: '-120' });
     expect(result.lat).toBe(45);

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -51,7 +51,7 @@ export type PlantFormSubmit = {
   lastWateredAt?: string;
   lastFertilizedAt?: string;
   createTasks?: boolean;
-  rules: {
+  plan: {
     type: 'water' | 'fertilize';
     intervalDays: number;
     amountMl?: number;
@@ -76,7 +76,7 @@ export function plantValuesToSubmit(s: PlantFormValues): PlantFormSubmit {
     indoor: s.indoor === 'Indoor',
     soilType: s.soil || undefined,
     drainage: s.drainage,
-    rules: [
+    plan: [
       {
         type: 'water',
         intervalDays: Number(s.waterEvery || 7),


### PR DESCRIPTION
## Summary
- rename `rules` to `plan` in `PlantFormSubmit` and request builders
- update API PATCH handler to accept `plan`
- adjust tests to expect `plan` field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51da1bde8832483cf0a38241b6bef