### PR TITLE
Simplify theme color palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,42 +4,36 @@
   :root {
     --font-display: "Cabinet Grotesk", ui-sans-serif, system-ui, sans-serif;
     --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-    --background: 210 20% 98%;
+    --background: 0 0% 100%;
     --foreground: 222 47% 11%;
-    --primary: 142 70% 45%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 222 47% 91%;
+    --primary: 221 83% 53%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96%;
     --secondary-foreground: 222 47% 11%;
     --muted: 215 16% 47%;
     --border: 214 32% 91%;
-    --accent: 200 100% 50%;
-    --accent-foreground: 0 0% 100%;
     --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    --success: 142 72% 36%;
-    --success-foreground: 0 0% 100%;
-    --warning: 35 92% 52%;
-    --warning-foreground: 0 0% 20%;
-  }
-  .dark {
-    --font-display: "Cabinet Grotesk", ui-sans-serif, system-ui, sans-serif;
-    --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-    --background: 222 47% 11%;
-    --foreground: 210 40% 98%;
-    --primary: 142 70% 45%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 222 47% 20%;
-    --secondary-foreground: 210 40% 96%;
-    --muted: 213 27% 52%;
-    --border: 213 27% 26%;
-    --accent: 200 100% 50%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 72% 50%;
     --destructive-foreground: 210 40% 98%;
     --success: 142 72% 36%;
-    --success-foreground: 0 0% 100%;
-    --warning: 35 92% 52%;
-    --warning-foreground: 0 0% 20%;
+    --success-foreground: 210 40% 98%;
+    --warning: 45 100% 51%;
+    --warning-foreground: 222 47% 11%;
+  }
+  .dark {
+    --background: 222 47% 11%;
+    --foreground: 210 40% 98%;
+    --primary: 221 83% 53%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 222 47% 20%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 215 16% 65%;
+    --border: 217 16% 26%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 210 40% 98%;
+    --success: 142 72% 36%;
+    --success-foreground: 210 40% 98%;
+    --warning: 45 100% 51%;
+    --warning-foreground: 210 40% 98%;
   }
   body {
     background-color: hsl(var(--background));

--- a/lib/__snapshots__/design-tokens.test.ts.snap
+++ b/lib/__snapshots__/design-tokens.test.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`design tokens matches dark token snapshot 1`] = `
 {
-  "background": "#111827",
-  "foreground": "#F9F9F9",
+  "background": "#0F172A",
+  "foreground": "#F9FAFB",
   "muted": "#9CA3AF",
-  "primary": "#508C7E",
-  "secondary": "#1E483D",
+  "primary": "#3B82F6",
+  "secondary": "#1F2937",
 }
 `;
 
 exports[`design tokens matches light token snapshot 1`] = `
 {
-  "background": "#F9F9F9",
+  "background": "#FFFFFF",
   "foreground": "#111827",
-  "muted": "#9CA3AF",
-  "primary": "#508C7E",
-  "secondary": "#D3EDE6",
+  "muted": "#6B7280",
+  "primary": "#3B82F6",
+  "secondary": "#F1F5F9",
 }
 `;

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,16 +1,16 @@
 export const lightTokens = {
-  primary: "#508C7E",
-  secondary: "#D3EDE6",
-  background: "#F9F9F9",
+  primary: "#3B82F6",
+  secondary: "#F1F5F9",
+  background: "#FFFFFF",
   foreground: "#111827",
-  muted: "#9CA3AF",
+  muted: "#6B7280",
 };
 
 export const darkTokens = {
-  primary: "#508C7E",
-  secondary: "#1E483D",
-  background: "#111827",
-  foreground: "#F9F9F9",
+  primary: "#3B82F6",
+  secondary: "#1F2937",
+  background: "#0F172A",
+  foreground: "#F9FAFB",
   muted: "#9CA3AF",
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,10 +24,6 @@ export default {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
         },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",


### PR DESCRIPTION
## Summary
- simplify light and dark theme variables
- drop unused accent color mapping
- update design tokens and snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52a2013b08324ac2cb57171833b9c