### PR TITLE
feat: add step navigation to add plant form

### DIFF
--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -1,30 +1,21 @@
 'use client';
 
-import { useForm } from 'react-hook-form';
+import { useForm, type UseFormRegister } from 'react-hook-form';
+import { useState } from 'react';
 
 export type AddPlantFormData = {
   name: string;
   roomId: string;
+  light: string;
+  waterInterval: string;
 };
 
-export default function AddPlantForm({
-  onSubmit,
-}: {
-  onSubmit: (data: AddPlantFormData) => void | Promise<void>;
-}) {
-  const { register, handleSubmit } = useForm<AddPlantFormData>({
-    defaultValues: { name: '', roomId: '' },
-  });
-
+function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
   return (
-    <form onSubmit={handleSubmit(onSubmit)} aria-label="plant-form" className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4">
       <label className="flex flex-col gap-1">
         <span className="font-medium">Name</span>
-        <input
-          type="text"
-          {...register('name')}
-          className="border rounded p-2"
-        />
+        <input type="text" {...register('name')} className="border rounded p-2" />
       </label>
       <label className="flex flex-col gap-1">
         <span className="font-medium">Room</span>
@@ -34,9 +25,85 @@ export default function AddPlantForm({
           <option value="bedroom">Bedroom</option>
         </select>
       </label>
-      <button type="submit" className="btn btn-primary self-start">
-        Add Plant
-      </button>
+    </div>
+  );
+}
+
+function EnvironmentStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Light</span>
+        <select {...register('light')} className="border rounded p-2">
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function CareStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Water every (days)</span>
+        <input
+          type="number"
+          {...register('waterInterval')}
+          className="border rounded p-2"
+          min={1}
+        />
+      </label>
+    </div>
+  );
+}
+
+export default function AddPlantForm({
+  onSubmit,
+}: {
+  onSubmit: (data: AddPlantFormData) => void | Promise<void>;
+}) {
+  const { register, handleSubmit } = useForm<AddPlantFormData>({
+    defaultValues: { name: '', roomId: '', light: 'medium', waterInterval: '7' },
+  });
+  const [step, setStep] = useState(0);
+
+  const steps = [
+    { title: 'Basics', component: <BasicsStep register={register} /> },
+    { title: 'Environment', component: <EnvironmentStep register={register} /> },
+    { title: 'Care', component: <CareStep register={register} /> },
+  ];
+
+  const next = () => setStep((s) => Math.min(s + 1, steps.length - 1));
+  const back = () => setStep((s) => Math.max(s - 1, 0));
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      aria-label="plant-form"
+      className="flex flex-col gap-6"
+    >
+      <h2 className="text-xl font-medium">{steps[step].title}</h2>
+      {steps[step].component}
+      <div className="flex gap-2">
+        {step > 0 && (
+          <button type="button" onClick={back} className="btn">
+            Back
+          </button>
+        )}
+        {step < steps.length - 1 && (
+          <button type="button" onClick={next} className="btn btn-primary">
+            Next
+          </button>
+        )}
+        {step === steps.length - 1 && (
+          <button type="submit" className="btn btn-primary self-start">
+            Add Plant
+          </button>
+        )}
+      </div>
     </form>
   );
 }

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddPlantForm from '../AddPlantForm';
+
+describe('AddPlantForm', () => {
+  it('navigates between steps and submits data', async () => {
+    const handleSubmit = jest.fn();
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={handleSubmit} />);
+
+    // Basics step
+    await user.type(screen.getByLabelText(/name/i), 'Ficus');
+    await user.selectOptions(screen.getByLabelText(/room/i), 'living');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Environment step
+    await user.selectOptions(screen.getByLabelText(/light/i), 'medium');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Care step
+    const waterInput = screen.getByLabelText(/water every/i);
+    await user.clear(waterInput);
+    await user.type(waterInput, '5');
+    await user.click(screen.getByRole('button', { name: /add plant/i }));
+
+    expect(handleSubmit).toHaveBeenCalled();
+    expect(handleSubmit.mock.calls[0][0]).toEqual({
+      name: 'Ficus',
+      roomId: 'living',
+      light: 'medium',
+      waterInterval: '5',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- split AddPlantForm into Basics, Environment, and Care steps with navigation
- track light and watering interval fields in the new steps
- add unit test covering step progression and submission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52ac6973483248bbfcd5269378e83