### PR TITLE
fix: transpile react-hook-form

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,2 +1,6 @@
-const nextConfig = {};
+// Ensure Next.js transpiles ESM-only dependencies like react-hook-form
+const nextConfig = {
+  transpilePackages: ['react-hook-form'],
+};
+
 export default nextConfig;


### PR DESCRIPTION
## Summary
- transpile react-hook-form so Next.js can bundle it properly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5371e8de08324b533be7c61a9c0e8