### PR TITLE
Send new plant form data to API

### DIFF
--- a/app/app/plants/new/__tests__/NewPlantPage.test.tsx
+++ b/app/app/plants/new/__tests__/NewPlantPage.test.tsx
@@ -3,24 +3,67 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import type { AddPlantFormData } from '@/components/forms/AddPlantForm';
 import NewPlantPage from '../page';
 
+const push = jest.fn();
+const refresh = jest.fn();
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useRouter: () => ({ push, refresh }),
 }));
+
+let submitHandler: ((data: AddPlantFormData) => void | Promise<void>) | undefined;
 
 jest.mock('@/components/forms/AddPlantForm', () => ({
   __esModule: true,
-  default: () => <form aria-label="plant-form" />,
+  default: (props: any) => {
+    submitHandler = props.onSubmit;
+    return <form aria-label="plant-form" />;
+  },
 }));
 
 describe('NewPlantPage', () => {
+  beforeEach(() => {
+    push.mockReset();
+    refresh.mockReset();
+    (global.fetch as any) = jest.fn();
+  });
+
   it('renders heading and plant form', () => {
     render(<NewPlantPage />);
     expect(
       screen.getByRole('heading', { name: /add plant/i })
     ).toBeInTheDocument();
     expect(screen.getByLabelText('plant-form')).toBeInTheDocument();
+  });
+
+  it('posts form data and navigates on success', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: '123' }),
+    });
+
+    render(<NewPlantPage />);
+    await submitHandler!({
+      name: 'Fern',
+      roomId: 'living',
+      light: 'medium',
+      waterInterval: '5',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/plants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Fern',
+        roomId: 'living',
+        lightLevel: 'medium',
+        plan: [{ type: 'water', intervalDays: 5 }],
+      }),
+    });
+    expect(push).toHaveBeenCalledWith('/app/plants/123/created');
+    expect(refresh).toHaveBeenCalled();
   });
 });
 

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -7,10 +7,22 @@ export default function NewPlantPage() {
   const router = useRouter();
 
   async function handleSubmit(data: AddPlantFormData) {
-    // Placeholder submit handler - replace with API call
-    // await fetch('/api/plants', {...})
-    console.log('submit', data);
-    router.back();
+    const res = await fetch('/api/plants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: data.name,
+        roomId: data.roomId,
+        lightLevel: data.light,
+        plan: [
+          { type: 'water', intervalDays: Number(data.waterInterval) || 7 },
+        ],
+      }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const plant = await res.json();
+    router.push(`/app/plants/${plant.id}/created`);
+    router.refresh();
   }
 
   return (


### PR DESCRIPTION
## Summary
- submit Add Plant form to `/api/plants` via POST
- redirect to created plant page and refresh on success
- test API call and navigation from New Plant page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53b2006ec8324848de2cb436e617a