### PR TITLE
Refactor ChipSelect styling with clsx

### DIFF
--- a/components/ChipSelect.tsx
+++ b/components/ChipSelect.tsx
@@ -1,6 +1,23 @@
 'use client';
 
 import { useRef } from 'react';
+import clsx from 'clsx';
+
+const baseClasses = [
+  'min-w-12 min-h-12 px-4 py-3 rounded-full border text-sm flex items-center justify-center',
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-neutral-900',
+  'dark:focus-visible:ring-neutral-100 focus-visible:ring-offset-white dark:focus-visible:ring-offset-neutral-800',
+].join(' ');
+
+const activeClasses = [
+  'bg-neutral-900 text-white border-neutral-900',
+  'dark:bg-neutral-100 dark:text-neutral-900 dark:border-neutral-100',
+].join(' ');
+
+const inactiveClasses = [
+  'bg-white text-neutral-900 border-neutral-300 hover:bg-neutral-100',
+  'dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-700',
+].join(' ');
 
 export function ChipSelect({
   options,
@@ -25,11 +42,10 @@ export function ChipSelect({
           aria-checked={value === opt}
           aria-label={opt}
           tabIndex={value === opt ? 0 : -1}
-          className={`min-w-12 min-h-12 px-4 py-3 rounded-full border text-sm flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-neutral-100 focus-visible:ring-offset-white dark:focus-visible:ring-offset-neutral-800 ${
-            value === opt
-              ? 'bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-neutral-900 dark:border-neutral-100'
-              : 'bg-white text-neutral-900 border-neutral-300 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-700'
-          }`}
+          className={clsx(
+            baseClasses,
+            value === opt ? activeClasses : inactiveClasses,
+          )}
           onClick={() => onChange(opt)}
           onKeyDown={(e) => {
             if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary
- refactor ChipSelect button classes to use `clsx`
- extract shared, active, and inactive style constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a53c75f8ec8324a654edd410c6c200