### PR TITLE
fix: improve contrast for status colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,9 +12,9 @@
     --secondary-foreground: 222 47% 11%;
     --muted: 215 16% 47%;
     --border: 214 32% 91%;
-    --destructive: 0 84% 60%;
+    --destructive: 0 84% 48%;
     --destructive-foreground: 210 40% 98%;
-    --success: 142 72% 36%;
+    --success: 142 72% 30%;
     --success-foreground: 210 40% 98%;
     --warning: 45 100% 51%;
     --warning-foreground: 222 47% 11%;
@@ -28,9 +28,9 @@
     --secondary-foreground: 210 40% 96%;
     --muted: 215 16% 65%;
     --border: 217 16% 26%;
-    --destructive: 0 84% 60%;
+    --destructive: 0 84% 48%;
     --destructive-foreground: 210 40% 98%;
-    --success: 142 72% 36%;
+    --success: 142 72% 30%;
     --success-foreground: 210 40% 98%;
     --warning: 45 100% 51%;
     --warning-foreground: 210 40% 98%;


### PR DESCRIPTION
## Summary
- darken destructive and success colors for WCAG AA contrast

## Testing
- `node -e "function hslToRgb(h,s,l){s/=100;l/=100;const k=n=> (n+ h/30)%12;const a=s*Math.min(l,1-l);const f=n=>l-a*Math.max(-1,Math.min(Math.min(k(n)-3,9-k(n)),1));return [f(0),f(8),f(4)].map(v=>Math.round(255*(v)));}function relativeLuminance(r,g,b){[r,g,b]=[r,g,b].map(v=>{v/=255;return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4)});return 0.2126*r+0.7152*g+0.0722*b;}function contrast(rgb1,rgb2){const L1=relativeLuminance(...rgb1);const L2=relativeLuminance(...rgb2);return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);}function hslStrToRgb(str){const [h,s,l]=str.split(/\s+/).map(v=>parseFloat(v));return hslToRgb(h,s,l);}const pairs=[['primary','221 83% 53%','210 40% 98%'],['destructive','0 84% 48%','210 40% 98%'],['success','142 72% 30%','210 40% 98%']];['light','dark'].forEach(theme=>{pairs.forEach(([name,bg,fg])=>{const ratio=contrast(hslStrToRgb(bg),hslStrToRgb(fg));console.log(theme,name,ratio.toFixed(2));});});"`
- `npm test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68a53c10883c83248ddd7dfeafcc14da