### PR TITLE
refactor: simplify care tip types

### DIFF
--- a/components/useCareTips.ts
+++ b/components/useCareTips.ts
@@ -2,20 +2,17 @@
 
 import { useMemo } from 'react';
 
-export type CareTipMap = {
-  potMaterial?: string;
-  light?: string;
-};
+export interface CareTipInput {
+  potMaterial: string;
+  light: string;
+}
 
-export type CareTipValues = {
-  potMaterial?: string;
-  light?: string;
-};
-
-export function useCareTips(values: CareTipValues | null): CareTipMap {
+export function useCareTips(
+  values: Partial<CareTipInput> | null,
+): Partial<CareTipInput> {
   return useMemo(() => {
     if (!values) return {};
-    const tips: CareTipMap = {};
+    const tips: Partial<CareTipInput> = {};
 
     switch (values.potMaterial) {
       case 'Terracotta':


### PR DESCRIPTION
## Summary
- consolidate care tip types into a single `CareTipInput` interface
- use `Partial` for hook input and output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a53e0421808324a1e7b555b164e1ed