### PR TITLE
refactor: treat water interval as number

### DIFF
--- a/app/app/plants/[id]/edit/EditPlantPage.tsx
+++ b/app/app/plants/[id]/edit/EditPlantPage.tsx
@@ -23,9 +23,7 @@ export default function EditPlantPage({
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
-        plan: [
-          { type: 'water', intervalDays: Number(data.waterInterval) || 7 },
-        ],
+        plan: [{ type: 'water', intervalDays: data.waterInterval || 7 }],
       }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -47,8 +45,8 @@ export default function EditPlantPage({
             light: (plant.lightLevel || 'medium').toLowerCase(),
             waterInterval:
               plant.waterIntervalDays !== undefined && plant.waterIntervalDays !== null
-                ? String(plant.waterIntervalDays)
-                : '7',
+                ? plant.waterIntervalDays
+                : 7,
           }}
           submitLabel="Save"
           onSubmit={handleSubmit}

--- a/app/app/plants/new/__tests__/NewPlantPage.test.tsx
+++ b/app/app/plants/new/__tests__/NewPlantPage.test.tsx
@@ -49,7 +49,7 @@ describe('NewPlantPage', () => {
       name: 'Fern',
       roomId: 'living',
       light: 'medium',
-      waterInterval: '5',
+      waterInterval: 5,
     });
 
     expect(fetch).toHaveBeenCalledWith('/api/plants', {

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -14,9 +14,7 @@ export default function NewPlantPage() {
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
-        plan: [
-          { type: 'water', intervalDays: Number(data.waterInterval) || 7 },
-        ],
+        plan: [{ type: 'water', intervalDays: data.waterInterval || 7 }],
       }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -7,7 +7,7 @@ export type AddPlantFormData = {
   name: string;
   roomId: string;
   light: string;
-  waterInterval: string;
+  waterInterval: number;
 };
 
 function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
@@ -51,7 +51,7 @@ function CareStep({ register }: { register: UseFormRegister<AddPlantFormData> })
         <span className="font-medium">Water every (days)</span>
         <input
           type="number"
-          {...register('waterInterval')}
+          {...register('waterInterval', { valueAsNumber: true })}
           className="border rounded p-2"
           min={1}
         />
@@ -77,7 +77,7 @@ export default function AddPlantForm({
         name: '',
         roomId: '',
         light: 'medium',
-        waterInterval: '7',
+        waterInterval: 7,
       },
   });
   const [step, setStep] = useState(0);

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -32,7 +32,7 @@ describe('AddPlantForm', () => {
       name: 'Ficus',
       roomId: 'living',
       light: 'medium',
-      waterInterval: '5',
+      waterInterval: 5,
     });
   });
 
@@ -45,7 +45,7 @@ describe('AddPlantForm', () => {
           name: 'Fern',
           roomId: 'bedroom',
           light: 'low',
-          waterInterval: '10',
+          waterInterval: 10,
         }}
         submitLabel="Save"
       />


### PR DESCRIPTION
## Summary
- change AddPlantForm waterInterval to number and register with valueAsNumber
- handle numeric waterInterval in plant creation and editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a53e0edba88324b286ddb8ad42d3eb