### PR TITLE
Align color palette across docs and tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,36 +4,36 @@
   :root {
     --font-display: "Cabinet Grotesk", ui-sans-serif, system-ui, sans-serif;
     --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-    --background: 0 0% 100%;
-    --foreground: 222 47% 11%;
-    --primary: 221 83% 53%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222 47% 11%;
-    --muted: 215 16% 47%;
-    --border: 214 32% 91%;
-    --destructive: 0 84% 48%;
-    --destructive-foreground: 210 40% 98%;
-    --success: 142 72% 30%;
-    --success-foreground: 210 40% 98%;
-    --warning: 45 100% 51%;
-    --warning-foreground: 222 47% 11%;
+    --background: 0 0% 98%;
+    --foreground: 221 39% 11%;
+    --primary: 166 27% 43%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 164 42% 88%;
+    --secondary-foreground: 221 39% 11%;
+    --muted: 218 11% 65%;
+    --border: 220 13% 91%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 221 39% 11%;
   }
   .dark {
-    --background: 222 47% 11%;
-    --foreground: 210 40% 98%;
-    --primary: 221 83% 53%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 222 47% 20%;
-    --secondary-foreground: 210 40% 96%;
-    --muted: 215 16% 65%;
-    --border: 217 16% 26%;
-    --destructive: 0 84% 48%;
-    --destructive-foreground: 210 40% 98%;
-    --success: 142 72% 30%;
-    --success-foreground: 210 40% 98%;
-    --warning: 45 100% 51%;
-    --warning-foreground: 210 40% 98%;
+    --background: 165 15% 5%;
+    --foreground: 220 13% 91%;
+    --primary: 166 27% 43%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 164 42% 88%;
+    --secondary-foreground: 221 39% 11%;
+    --muted: 218 11% 65%;
+    --border: 169 15% 14%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 221 39% 11%;
   }
   body {
     background-color: hsl(var(--background));

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,7 +1,7 @@
 # Kay Maria Style Guide
 
 _A living spec for design & implementation. Keep this in `/docs/STYLEGUIDE.md` and update alongside UI changes._  
-_Last updated: 2025-08-19_
+_Last updated: 2025-10-30_
 
 ---
 
@@ -19,7 +19,7 @@ Use semantic roles so components don’t rely on raw hex values.
 ### Functional Roles
 - **Success**: `#16A34A`
 - **Warning**: `#F59E0B`
-- **Error**: `#DC2626`
+- **Error/Destructive**: `#DC2626`
 - **Borders**: `#E5E7EB` (default), `#F1F5F9` (subtle)
 
 > **Rule:** Use semantic roles in code (e.g., `text-text`, `bg-surface-1`, `border-border`) rather than raw hex.
@@ -196,4 +196,5 @@ Use this to validate each view against the style guide.
 ## Changelog
 
 - **2025-08-19:** Explicit revision: tokens, components, state matrix, patterns, and dark mode. QA checklist template added.
+- **2025-10-30:** Palette synchronized across design tokens and global styles.
 

--- a/lib/__snapshots__/design-tokens.test.ts.snap
+++ b/lib/__snapshots__/design-tokens.test.ts.snap
@@ -1,21 +1,29 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`design tokens matches dark token snapshot 1`] = `
 {
-  "background": "#0F172A",
-  "foreground": "#F9FAFB",
+  "background": "#0B0F0E",
+  "border": "#1F2A28",
+  "destructive": "#DC2626",
+  "foreground": "#E5E7EB",
   "muted": "#9CA3AF",
-  "primary": "#3B82F6",
-  "secondary": "#1F2937",
+  "primary": "#508C7E",
+  "secondary": "#D3EDE6",
+  "success": "#16A34A",
+  "warning": "#F59E0B",
 }
 `;
 
 exports[`design tokens matches light token snapshot 1`] = `
 {
-  "background": "#FFFFFF",
+  "background": "#F9F9F9",
+  "border": "#E5E7EB",
+  "destructive": "#DC2626",
   "foreground": "#111827",
-  "muted": "#6B7280",
-  "primary": "#3B82F6",
-  "secondary": "#F1F5F9",
+  "muted": "#9CA3AF",
+  "primary": "#508C7E",
+  "secondary": "#D3EDE6",
+  "success": "#16A34A",
+  "warning": "#F59E0B",
 }
 `;

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,17 +1,25 @@
 export const lightTokens = {
-  primary: "#3B82F6",
-  secondary: "#F1F5F9",
-  background: "#FFFFFF",
+  primary: "#508C7E",
+  secondary: "#D3EDE6",
+  background: "#F9F9F9",
   foreground: "#111827",
-  muted: "#6B7280",
+  muted: "#9CA3AF",
+  border: "#E5E7EB",
+  success: "#16A34A",
+  warning: "#F59E0B",
+  destructive: "#DC2626",
 };
 
 export const darkTokens = {
-  primary: "#3B82F6",
-  secondary: "#1F2937",
-  background: "#0F172A",
-  foreground: "#F9FAFB",
+  primary: "#508C7E",
+  secondary: "#D3EDE6",
+  background: "#0B0F0E",
+  foreground: "#E5E7EB",
   muted: "#9CA3AF",
+  border: "#1F2A28",
+  success: "#16A34A",
+  warning: "#F59E0B",
+  destructive: "#DC2626",
 };
 
 export const coreColors = lightTokens;


### PR DESCRIPTION
## Summary
- synchronize design tokens and global CSS with style-guide palette
- document palette reconciliation and rename error to error/destructive
- update design token snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53e4d7ca08324bd975e2b6e1eda2a