### PR TITLE
Use numeric water interval in plant form

### DIFF
--- a/app/app/plants/[id]/edit/EditPlantPage.tsx
+++ b/app/app/plants/[id]/edit/EditPlantPage.tsx
@@ -24,7 +24,7 @@ export default function EditPlantPage({
         roomId: data.roomId,
         lightLevel: data.light,
         plan: [
-          { type: 'water', intervalDays: Number(data.waterInterval) || 7 },
+          { type: 'water', intervalDays: data.waterInterval || 7 },
         ],
       }),
     });
@@ -45,10 +45,7 @@ export default function EditPlantPage({
             name: plant.name,
             roomId: plant.roomId || '',
             light: (plant.lightLevel || 'medium').toLowerCase(),
-            waterInterval:
-              plant.waterIntervalDays !== undefined && plant.waterIntervalDays !== null
-                ? String(plant.waterIntervalDays)
-                : '7',
+            waterInterval: plant.waterIntervalDays ?? 7,
           }}
           submitLabel="Save"
           onSubmit={handleSubmit}

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -15,7 +15,7 @@ export default function NewPlantPage() {
         roomId: data.roomId,
         lightLevel: data.light,
         plan: [
-          { type: 'water', intervalDays: Number(data.waterInterval) || 7 },
+          { type: 'water', intervalDays: data.waterInterval || 7 },
         ],
       }),
     });

--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -7,7 +7,7 @@ export type AddPlantFormData = {
   name: string;
   roomId: string;
   light: string;
-  waterInterval: string;
+  waterInterval: number;
 };
 
 function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
@@ -51,7 +51,7 @@ function CareStep({ register }: { register: UseFormRegister<AddPlantFormData> })
         <span className="font-medium">Water every (days)</span>
         <input
           type="number"
-          {...register('waterInterval')}
+          {...register('waterInterval', { valueAsNumber: true })}
           className="border rounded p-2"
           min={1}
         />
@@ -77,7 +77,7 @@ export default function AddPlantForm({
         name: '',
         roomId: '',
         light: 'medium',
-        waterInterval: '7',
+        waterInterval: 7,
       },
   });
   const [step, setStep] = useState(0);

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -32,7 +32,7 @@ describe('AddPlantForm', () => {
       name: 'Ficus',
       roomId: 'living',
       light: 'medium',
-      waterInterval: '5',
+      waterInterval: 5,
     });
   });
 
@@ -45,7 +45,7 @@ describe('AddPlantForm', () => {
           name: 'Fern',
           roomId: 'bedroom',
           light: 'low',
-          waterInterval: '10',
+          waterInterval: 10,
         }}
         submitLabel="Save"
       />


### PR DESCRIPTION
## Summary
- treat `waterInterval` as number in `AddPlantForm`
- adjust plant pages to pass numeric water intervals
- update form tests for numeric interval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53f97fefc8324a84dc09d62bf16ff