### PR TITLE
Remove pencil icon from plant detail header

### DIFF
--- a/app/app/plants/[id]/PlantDetailClient.tsx
+++ b/app/app/plants/[id]/PlantDetailClient.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
  import { useEffect, useMemo, useState, useRef } from "react";
  import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { ArrowLeft, Droplet, FlaskConical, Sprout, MoreVertical, Pencil } from "lucide-react";
+import { ArrowLeft, Droplet, FlaskConical, Sprout, MoreVertical } from "lucide-react";
 
 import BottomNav from '@/components/BottomNav';
 import CareSummary from '@/components/CareSummary';
@@ -301,14 +301,7 @@ export default function PlantDetailClient({ plant }: { plant: Plant & PlantExtra
                 {new Intl.DateTimeFormat(undefined, { weekday:"short", month:"short", day:"numeric" }).format(new Date())}
               </span>
 
-              <Link
-                href={`/app/plants/${id}/edit`}
-                aria-label="Edit plant"
-                className="h-9 w-9 rounded-lg grid place-items-center hover:bg-secondary"
-              >
-                <Pencil className="h-5 w-5" />
-              </Link>
-              <div ref={menuRef} className="relative">
+                <div ref={menuRef} className="relative">
 
                 <button
                   aria-label="More options"


### PR DESCRIPTION
## Summary
- remove redundant pencil edit icon from plant detail page header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a54315e0d88324ae921e57684fc1af