### PR TITLE
Add Zod validation for AddPlantForm

### DIFF
--- a/app/app/plants/[id]/edit/EditPlantPage.tsx
+++ b/app/app/plants/[id]/edit/EditPlantPage.tsx
@@ -24,7 +24,7 @@ export default function EditPlantPage({
         roomId: data.roomId,
         lightLevel: data.light,
         plan: [
-          { type: 'water', intervalDays: data.waterInterval || 7 },
+          { type: 'water', intervalDays: data.waterEvery || 7 },
         ],
       }),
     });
@@ -45,7 +45,7 @@ export default function EditPlantPage({
             name: plant.name,
             roomId: plant.roomId || '',
             light: (plant.lightLevel || 'medium').toLowerCase(),
-            waterInterval: plant.waterIntervalDays ?? 7,
+            waterEvery: plant.waterIntervalDays ?? 7,
           }}
           submitLabel="Save"
           onSubmit={handleSubmit}

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -15,7 +15,7 @@ export default function NewPlantPage() {
         roomId: data.roomId,
         lightLevel: data.light,
         plan: [
-          { type: 'water', intervalDays: data.waterInterval || 7 },
+          { type: 'water', intervalDays: data.waterEvery || 7 },
         ],
       }),
     });

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -32,7 +32,7 @@ describe('AddPlantForm', () => {
       name: 'Ficus',
       roomId: 'living',
       light: 'medium',
-      waterInterval: 5,
+      waterEvery: 5,
     });
   });
 
@@ -45,7 +45,7 @@ describe('AddPlantForm', () => {
           name: 'Fern',
           roomId: 'bedroom',
           light: 'low',
-          waterInterval: 10,
+          waterEvery: 10,
         }}
         submitLabel="Save"
       />
@@ -55,5 +55,41 @@ describe('AddPlantForm', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
     await user.click(screen.getByRole('button', { name: /next/i }));
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('shows errors on required basics fields', async () => {
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(await screen.findByText(/enter a plant name/i)).toBeInTheDocument();
+    expect(screen.getByText(/choose a room or add one/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /basics/i })).toBeInTheDocument();
+  });
+
+  it('blocks submit when care values invalid until corrected', async () => {
+    const handleSubmit = jest.fn();
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={handleSubmit} />);
+
+    // pass basics and environment
+    await user.type(screen.getByLabelText(/name/i), 'Ficus');
+    await user.selectOptions(screen.getByLabelText(/room/i), 'living');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    const waterInput = screen.getByLabelText(/water every/i);
+    await user.clear(waterInput);
+    await user.type(waterInput, '0');
+    await user.click(screen.getByRole('button', { name: /add plant/i }));
+
+    expect(await screen.findByText(/must be at least 1 day/i)).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    await user.clear(waterInput);
+    await user.type(waterInput, '3');
+    await user.click(screen.getByRole('button', { name: /add plant/i }));
+    expect(handleSubmit).toHaveBeenCalled();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@headlessui/react": "^2.2.7",
+        "@hookform/resolvers": "^3.10.0",
         "@prisma/client": "^6.14.0",
         "@supabase/supabase-js": "^2.55.0",
         "chart.js": "^4.5.0",
@@ -871,6 +872,15 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
+    "@hookform/resolvers": "^3.10.0",
     "@prisma/client": "^6.14.0",
     "@supabase/supabase-js": "^2.55.0",
     "chart.js": "^4.5.0",


### PR DESCRIPTION
## Summary
- validate AddPlantForm fields with zodResolver and show inline errors
- enforce step-wise validation in the form wizard
- test form validation including error messaging and submission blocking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5432fe6488324b545c40480c2f1d8