### PR TITLE
feat: load rooms dynamically in plant form

### DIFF
--- a/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
+++ b/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
@@ -17,7 +17,10 @@ describe('EditPlantPage', () => {
   beforeEach(() => {
     push.mockReset();
     refresh.mockReset();
-    (global.fetch as any) = jest.fn();
+    (global.fetch as any) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
   });
 
   it('renders heading and form', () => {
@@ -43,10 +46,18 @@ describe('EditPlantPage', () => {
       lightLevel: 'medium',
       waterIntervalDays: 5,
     };
-    (fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({}),
-    });
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'living', name: 'Living Room' },
+          { id: 'bedroom', name: 'Bedroom' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
     const user = userEvent.setup();
     render(<EditPlantPage plant={plant} />);
 

--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useForm, type UseFormRegister } from 'react-hook-form';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { getRooms, type Room } from '@/lib/rooms';
 
 export type AddPlantFormData = {
   name: string;
@@ -10,7 +11,13 @@ export type AddPlantFormData = {
   waterInterval: number;
 };
 
-function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
+function BasicsStep({
+  register,
+  rooms,
+}: {
+  register: UseFormRegister<AddPlantFormData>;
+  rooms: Room[];
+}) {
   return (
     <div className="flex flex-col gap-4">
       <label className="flex flex-col gap-1">
@@ -21,8 +28,11 @@ function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> 
         <span className="font-medium">Room</span>
         <select {...register('roomId')} className="border rounded p-2">
           <option value="">Select a room</option>
-          <option value="living">Living Room</option>
-          <option value="bedroom">Bedroom</option>
+          {rooms.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.name}
+            </option>
+          ))}
         </select>
       </label>
     </div>
@@ -71,7 +81,7 @@ export default function AddPlantForm({
   initialValues,
   submitLabel,
 }: AddPlantFormProps) {
-  const { register, handleSubmit } = useForm<AddPlantFormData>({
+  const { register, handleSubmit, setValue } = useForm<AddPlantFormData>({
     defaultValues:
       initialValues ?? {
         name: '',
@@ -81,9 +91,22 @@ export default function AddPlantForm({
       },
   });
   const [step, setStep] = useState(0);
+  const [rooms, setRooms] = useState<Room[]>([]);
+
+  useEffect(() => {
+    getRooms()
+      .then(setRooms)
+      .catch((e) => console.error('Failed to load rooms', e));
+  }, []);
+
+  useEffect(() => {
+    if (rooms.length && initialValues?.roomId) {
+      setValue('roomId', initialValues.roomId);
+    }
+  }, [rooms, initialValues?.roomId, setValue]);
 
   const steps = [
-    { title: 'Basics', component: <BasicsStep register={register} /> },
+    { title: 'Basics', component: <BasicsStep register={register} rooms={rooms} /> },
     { title: 'Environment', component: <EnvironmentStep register={register} /> },
     { title: 'Care', component: <CareStep register={register} /> },
   ];

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -6,6 +6,22 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AddPlantForm from '../AddPlantForm';
 
+const mockRooms = [
+  { id: 'living', name: 'Living Room' },
+  { id: 'bedroom', name: 'Bedroom' },
+];
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(mockRooms),
+  } as any);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
 describe('AddPlantForm', () => {
   it('navigates between steps and submits data', async () => {
     const handleSubmit = jest.fn();
@@ -13,6 +29,7 @@ describe('AddPlantForm', () => {
     render(<AddPlantForm onSubmit={handleSubmit} />);
 
     // Basics step
+    await screen.findByRole('option', { name: 'Living Room' });
     await user.type(screen.getByLabelText(/name/i), 'Ficus');
     await user.selectOptions(screen.getByLabelText(/room/i), 'living');
     await user.click(screen.getByRole('button', { name: /next/i }));
@@ -50,10 +67,17 @@ describe('AddPlantForm', () => {
         submitLabel="Save"
       />
     );
+    await screen.findByRole('option', { name: 'Bedroom' });
     expect(screen.getByLabelText(/name/i)).toHaveValue('Fern');
     expect(screen.getByLabelText(/room/i)).toHaveValue('bedroom');
     await user.click(screen.getByRole('button', { name: /next/i }));
     await user.click(screen.getByRole('button', { name: /next/i }));
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('loads rooms from API', async () => {
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+    expect(await screen.findByRole('option', { name: 'Living Room' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Bedroom' })).toBeInTheDocument();
   });
 });

--- a/lib/rooms.ts
+++ b/lib/rooms.ts
@@ -1,0 +1,7 @@
+import { fetchJson } from './fetchJson';
+
+export type Room = { id: string; name: string };
+
+export async function getRooms() {
+  return fetchJson<Room[]>('/api/rooms');
+}


### PR DESCRIPTION
## Summary
- add `getRooms` helper to fetch user rooms
- load rooms in `AddPlantForm` and render options dynamically
- update form tests to mock room fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5433466288324aa9be609e7210973