### PR TITLE
feat: add stepper navigation to add plant form

### DIFF
--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -56,4 +56,32 @@ describe('AddPlantForm', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
   });
+
+  it('stepper reflects current step', async () => {
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /basics/i })).toHaveAttribute(
+      'aria-current',
+      'step'
+    );
+    await user.type(screen.getByLabelText(/name/i), 'Ficus');
+    await user.selectOptions(screen.getByLabelText(/room/i), 'living');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(
+      screen.getByRole('button', { name: /environment/i })
+    ).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('allows back navigation via the stepper', async () => {
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+    await user.type(screen.getByLabelText(/name/i), 'Ficus');
+    await user.selectOptions(screen.getByLabelText(/room/i), 'living');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /basics/i }));
+    expect(screen.getByRole('button', { name: /basics/i })).toHaveAttribute(
+      'aria-current',
+      'step'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add labeled stepper to AddPlantForm
- block forward navigation until current step is valid
- test stepper state and back-navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5433844188324b3f23f86f2d89325