### PR TITLE
Expand plant form for full care fields

### DIFF
--- a/app/app/plants/[id]/edit/EditPlantPage.tsx
+++ b/app/app/plants/[id]/edit/EditPlantPage.tsx
@@ -6,6 +6,12 @@ import type { Plant } from '@prisma/client';
 
 type PlantExtras = {
   waterIntervalDays?: number | null;
+  waterAmountMl?: number | null;
+  fertIntervalDays?: number | null;
+  lastWateredAt?: Date | string | null;
+  lastFertilizedAt?: Date | string | null;
+  latitude?: number | null;
+  longitude?: number | null;
 };
 
 export default function EditPlantPage({
@@ -23,8 +29,21 @@ export default function EditPlantPage({
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
+        lat: data.lat,
+        lon: data.lon,
+        lastWateredAt: data.lastWatered
+          ? new Date(data.lastWatered).toISOString()
+          : undefined,
+        lastFertilizedAt: data.lastFertilized
+          ? new Date(data.lastFertilized).toISOString()
+          : undefined,
         plan: [
-          { type: 'water', intervalDays: data.waterInterval || 7 },
+          {
+            type: 'water',
+            intervalDays: data.waterEvery || 7,
+            amountMl: data.waterAmount,
+          },
+          { type: 'fertilize', intervalDays: data.fertEvery },
         ],
       }),
     });
@@ -45,7 +64,17 @@ export default function EditPlantPage({
             name: plant.name,
             roomId: plant.roomId || '',
             light: (plant.lightLevel || 'medium').toLowerCase(),
-            waterInterval: plant.waterIntervalDays ?? 7,
+            lat: plant.latitude ?? undefined,
+            lon: plant.longitude ?? undefined,
+            waterEvery: plant.waterIntervalDays ?? 7,
+            waterAmount: plant.waterAmountMl ?? 500,
+            fertEvery: plant.fertIntervalDays ?? 30,
+            lastWatered: plant.lastWateredAt
+              ? new Date(plant.lastWateredAt).toISOString().slice(0, 10)
+              : '',
+            lastFertilized: plant.lastFertilizedAt
+              ? new Date(plant.lastFertilizedAt).toISOString().slice(0, 10)
+              : '',
           }}
           submitLabel="Save"
           onSubmit={handleSubmit}

--- a/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
+++ b/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
@@ -27,6 +27,12 @@ describe('EditPlantPage', () => {
       roomId: 'living',
       lightLevel: 'medium',
       waterIntervalDays: 5,
+      waterAmountMl: 500,
+      fertIntervalDays: 60,
+      lastWateredAt: '2024-01-01',
+      lastFertilizedAt: '2024-01-02',
+      latitude: 1.23,
+      longitude: 4.56,
     };
     render(<EditPlantPage plant={plant} />);
     expect(
@@ -42,6 +48,12 @@ describe('EditPlantPage', () => {
       roomId: 'living',
       lightLevel: 'medium',
       waterIntervalDays: 5,
+      waterAmountMl: 500,
+      fertIntervalDays: 60,
+      lastWateredAt: '2024-01-01',
+      lastFertilizedAt: '2024-01-02',
+      latitude: 1.23,
+      longitude: 4.56,
     };
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
@@ -56,11 +68,22 @@ describe('EditPlantPage', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await user.selectOptions(screen.getByLabelText(/light/i), 'low');
+    await user.clear(screen.getByLabelText(/latitude/i));
+    await user.type(screen.getByLabelText(/latitude/i), '9.87');
+    await user.clear(screen.getByLabelText(/longitude/i));
+    await user.type(screen.getByLabelText(/longitude/i), '65.43');
     await user.click(screen.getByRole('button', { name: /next/i }));
 
-    const waterInput = screen.getByLabelText(/water every/i);
-    await user.clear(waterInput);
-    await user.type(waterInput, '10');
+    await user.clear(screen.getByLabelText(/water every/i));
+    await user.type(screen.getByLabelText(/water every/i), '10');
+    await user.clear(screen.getByLabelText(/water amount/i));
+    await user.type(screen.getByLabelText(/water amount/i), '700');
+    await user.clear(screen.getByLabelText(/fertilize every/i));
+    await user.type(screen.getByLabelText(/fertilize every/i), '40');
+    await user.clear(screen.getByLabelText(/last watered/i));
+    await user.type(screen.getByLabelText(/last watered/i), '2024-01-03');
+    await user.clear(screen.getByLabelText(/last fertilized/i));
+    await user.type(screen.getByLabelText(/last fertilized/i), '2024-01-04');
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     expect(fetch).toHaveBeenCalledWith('/api/plants/1', {
@@ -70,7 +93,14 @@ describe('EditPlantPage', () => {
         name: 'Snake Plant',
         roomId: 'bedroom',
         lightLevel: 'low',
-        plan: [{ type: 'water', intervalDays: 10 }],
+        lat: 9.87,
+        lon: 65.43,
+        lastWateredAt: '2024-01-03T00:00:00.000Z',
+        lastFertilizedAt: '2024-01-04T00:00:00.000Z',
+        plan: [
+          { type: 'water', intervalDays: 10, amountMl: 700 },
+          { type: 'fertilize', intervalDays: 40 },
+        ],
       }),
     });
     expect(push).toHaveBeenCalledWith('/app/plants/1');

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -14,8 +14,21 @@ export default function NewPlantPage() {
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
+        lat: data.lat,
+        lon: data.lon,
+        lastWateredAt: data.lastWatered
+          ? new Date(data.lastWatered).toISOString()
+          : undefined,
+        lastFertilizedAt: data.lastFertilized
+          ? new Date(data.lastFertilized).toISOString()
+          : undefined,
         plan: [
-          { type: 'water', intervalDays: data.waterInterval || 7 },
+          {
+            type: 'water',
+            intervalDays: data.waterEvery || 7,
+            amountMl: data.waterAmount,
+          },
+          { type: 'fertilize', intervalDays: data.fertEvery },
         ],
       }),
     });

--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -7,7 +7,13 @@ export type AddPlantFormData = {
   name: string;
   roomId: string;
   light: string;
-  waterInterval: number;
+  lat?: number;
+  lon?: number;
+  waterEvery: number;
+  waterAmount: number;
+  fertEvery: number;
+  lastWatered?: string;
+  lastFertilized?: string;
 };
 
 function BasicsStep({ register }: { register: UseFormRegister<AddPlantFormData> }) {
@@ -40,6 +46,24 @@ function EnvironmentStep({ register }: { register: UseFormRegister<AddPlantFormD
           <option value="high">High</option>
         </select>
       </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Latitude</span>
+        <input
+          type="number"
+          step="any"
+          {...register('lat', { valueAsNumber: true })}
+          className="border rounded p-2"
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Longitude</span>
+        <input
+          type="number"
+          step="any"
+          {...register('lon', { valueAsNumber: true })}
+          className="border rounded p-2"
+        />
+      </label>
     </div>
   );
 }
@@ -51,10 +75,36 @@ function CareStep({ register }: { register: UseFormRegister<AddPlantFormData> })
         <span className="font-medium">Water every (days)</span>
         <input
           type="number"
-          {...register('waterInterval', { valueAsNumber: true })}
+          {...register('waterEvery', { valueAsNumber: true })}
           className="border rounded p-2"
           min={1}
         />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Water amount (ml)</span>
+        <input
+          type="number"
+          {...register('waterAmount', { valueAsNumber: true })}
+          className="border rounded p-2"
+          min={10}
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Fertilize every (days)</span>
+        <input
+          type="number"
+          {...register('fertEvery', { valueAsNumber: true })}
+          className="border rounded p-2"
+          min={1}
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Last watered</span>
+        <input type="date" {...register('lastWatered')} className="border rounded p-2" />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Last fertilized</span>
+        <input type="date" {...register('lastFertilized')} className="border rounded p-2" />
       </label>
     </div>
   );
@@ -77,7 +127,13 @@ export default function AddPlantForm({
         name: '',
         roomId: '',
         light: 'medium',
-        waterInterval: 7,
+        lat: undefined,
+        lon: undefined,
+        waterEvery: 7,
+        waterAmount: 500,
+        fertEvery: 30,
+        lastWatered: '',
+        lastFertilized: '',
       },
   });
   const [step, setStep] = useState(0);

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -19,12 +19,19 @@ describe('AddPlantForm', () => {
 
     // Environment step
     await user.selectOptions(screen.getByLabelText(/light/i), 'medium');
+    await user.type(screen.getByLabelText(/latitude/i), '12.34');
+    await user.type(screen.getByLabelText(/longitude/i), '56.78');
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     // Care step
-    const waterInput = screen.getByLabelText(/water every/i);
-    await user.clear(waterInput);
-    await user.type(waterInput, '5');
+    await user.clear(screen.getByLabelText(/water every/i));
+    await user.type(screen.getByLabelText(/water every/i), '5');
+    await user.clear(screen.getByLabelText(/water amount/i));
+    await user.type(screen.getByLabelText(/water amount/i), '600');
+    await user.clear(screen.getByLabelText(/fertilize every/i));
+    await user.type(screen.getByLabelText(/fertilize every/i), '30');
+    await user.type(screen.getByLabelText(/last watered/i), '2024-01-01');
+    await user.type(screen.getByLabelText(/last fertilized/i), '2024-01-02');
     await user.click(screen.getByRole('button', { name: /add plant/i }));
 
     expect(handleSubmit).toHaveBeenCalled();
@@ -32,7 +39,13 @@ describe('AddPlantForm', () => {
       name: 'Ficus',
       roomId: 'living',
       light: 'medium',
-      waterInterval: 5,
+      lat: 12.34,
+      lon: 56.78,
+      waterEvery: 5,
+      waterAmount: 600,
+      fertEvery: 30,
+      lastWatered: '2024-01-01',
+      lastFertilized: '2024-01-02',
     });
   });
 
@@ -45,7 +58,13 @@ describe('AddPlantForm', () => {
           name: 'Fern',
           roomId: 'bedroom',
           light: 'low',
-          waterInterval: 10,
+          lat: 1.23,
+          lon: 4.56,
+          waterEvery: 10,
+          waterAmount: 500,
+          fertEvery: 60,
+          lastWatered: '2024-01-01',
+          lastFertilized: '2024-01-02',
         }}
         submitLabel="Save"
       />


### PR DESCRIPTION
## Summary
- add location, water and fertilizer inputs to AddPlantForm
- send new plant care fields to API on create and edit
- test new form fields round-trip through submission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5433e2da083248b5d9382c256eee3