### PR TITLE
feat: extend plant form with care and location fields

### DIFF
--- a/app/app/plants/[id]/edit/EditPlantPage.tsx
+++ b/app/app/plants/[id]/edit/EditPlantPage.tsx
@@ -23,8 +23,21 @@ export default function EditPlantPage({
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
+        lat: data.lat,
+        lon: data.lon,
+        lastWateredAt: data.lastWatered
+          ? new Date(data.lastWatered).toISOString()
+          : undefined,
+        lastFertilizedAt: data.lastFertilized
+          ? new Date(data.lastFertilized).toISOString()
+          : undefined,
         plan: [
-          { type: 'water', intervalDays: data.waterEvery || 7 },
+          {
+            type: 'water',
+            intervalDays: data.waterEvery || 7,
+            amountMl: data.waterAmount,
+          },
+          { type: 'fertilize', intervalDays: data.fertEvery || 30 },
         ],
       }),
     });
@@ -46,6 +59,16 @@ export default function EditPlantPage({
             roomId: plant.roomId || '',
             light: (plant.lightLevel || 'medium').toLowerCase(),
             waterEvery: plant.waterIntervalDays ?? 7,
+            waterAmount: 250,
+            fertEvery: 30,
+            lastWatered: plant.lastWateredAt
+              ? plant.lastWateredAt.toISOString().slice(0, 10)
+              : '',
+            lastFertilized: plant.lastFertilizedAt
+              ? plant.lastFertilizedAt.toISOString().slice(0, 10)
+              : '',
+            lat: plant.latitude ?? undefined,
+            lon: plant.longitude ?? undefined,
           }}
           submitLabel="Save"
           onSubmit={handleSubmit}

--- a/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
+++ b/app/app/plants/[id]/edit/__tests__/EditPlantPage.test.tsx
@@ -56,11 +56,24 @@ describe('EditPlantPage', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await user.selectOptions(screen.getByLabelText(/light/i), 'low');
+    await user.type(screen.getByLabelText(/latitude/i), '10');
+    await user.type(screen.getByLabelText(/longitude/i), '20');
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     const waterInput = screen.getByLabelText(/water every/i);
     await user.clear(waterInput);
     await user.type(waterInput, '10');
+    const waterAmount = screen.getByLabelText(/water amount/i);
+    await user.clear(waterAmount);
+    await user.type(waterAmount, '400');
+    const fertInput = screen.getByLabelText(/fertilize every/i);
+    await user.clear(fertInput);
+    await user.type(fertInput, '45');
+    await user.type(screen.getByLabelText(/last watered/i), '2024-03-01');
+    await user.type(
+      screen.getByLabelText(/last fertilized/i),
+      '2024-03-10'
+    );
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     expect(fetch).toHaveBeenCalledWith('/api/plants/1', {
@@ -70,7 +83,14 @@ describe('EditPlantPage', () => {
         name: 'Snake Plant',
         roomId: 'bedroom',
         lightLevel: 'low',
-        plan: [{ type: 'water', intervalDays: 10 }],
+        lat: 10,
+        lon: 20,
+        lastWateredAt: '2024-03-01T00:00:00.000Z',
+        lastFertilizedAt: '2024-03-10T00:00:00.000Z',
+        plan: [
+          { type: 'water', intervalDays: 10, amountMl: 400 },
+          { type: 'fertilize', intervalDays: 45 },
+        ],
       }),
     });
     expect(push).toHaveBeenCalledWith('/app/plants/1');

--- a/app/app/plants/new/page.tsx
+++ b/app/app/plants/new/page.tsx
@@ -14,8 +14,21 @@ export default function NewPlantPage() {
         name: data.name,
         roomId: data.roomId,
         lightLevel: data.light,
+        lat: data.lat,
+        lon: data.lon,
+        lastWateredAt: data.lastWatered
+          ? new Date(data.lastWatered).toISOString()
+          : undefined,
+        lastFertilizedAt: data.lastFertilized
+          ? new Date(data.lastFertilized).toISOString()
+          : undefined,
         plan: [
-          { type: 'water', intervalDays: data.waterEvery || 7 },
+          {
+            type: 'water',
+            intervalDays: data.waterEvery || 7,
+            amountMl: data.waterAmount,
+          },
+          { type: 'fertilize', intervalDays: data.fertEvery || 30 },
         ],
       }),
     });

--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -15,6 +15,12 @@ export type AddPlantFormData = {
   roomId: string;
   light: string;
   waterEvery: number;
+  waterAmount: number;
+  fertEvery: number;
+  lastWatered?: string;
+  lastFertilized?: string;
+  lat?: number;
+  lon?: number;
 };
 
 type StepProps = {
@@ -54,7 +60,7 @@ function BasicsStep({ register, errors }: StepProps) {
   );
 }
 
-function EnvironmentStep({ register }: StepProps) {
+function EnvironmentStep({ register, errors }: StepProps) {
   return (
     <div className="flex flex-col gap-4">
       <label className="flex flex-col gap-1">
@@ -64,6 +70,34 @@ function EnvironmentStep({ register }: StepProps) {
           <option value="medium">Medium</option>
           <option value="high">High</option>
         </select>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Latitude</span>
+        <input
+          type="number"
+          step="any"
+          {...register('lat')}
+          className={`border rounded p-2 ${errors.lat ? 'border-red-500' : ''}`}
+          min={-90}
+          max={90}
+        />
+        {errors.lat && (
+          <p className="text-sm text-red-600">{errors.lat.message}</p>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Longitude</span>
+        <input
+          type="number"
+          step="any"
+          {...register('lon')}
+          className={`border rounded p-2 ${errors.lon ? 'border-red-500' : ''}`}
+          min={-180}
+          max={180}
+        />
+        {errors.lon && (
+          <p className="text-sm text-red-600">{errors.lon.message}</p>
+        )}
       </label>
     </div>
   );
@@ -82,6 +116,48 @@ function CareStep({ register, errors }: StepProps) {
         />
         {errors.waterEvery && (
           <p className="text-sm text-red-600">{errors.waterEvery.message}</p>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Water amount (ml)</span>
+        <input
+          type="number"
+          {...register('waterAmount', { valueAsNumber: true })}
+          className={`border rounded p-2 ${errors.waterAmount ? 'border-red-500' : ''}`}
+          min={10}
+        />
+        {errors.waterAmount && (
+          <p className="text-sm text-red-600">{errors.waterAmount.message}</p>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Fertilize every (days)</span>
+        <input
+          type="number"
+          {...register('fertEvery', { valueAsNumber: true })}
+          className={`border rounded p-2 ${errors.fertEvery ? 'border-red-500' : ''}`}
+          min={1}
+        />
+        {errors.fertEvery && (
+          <p className="text-sm text-red-600">{errors.fertEvery.message}</p>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Last watered</span>
+        <input type="date" {...register('lastWatered')} className="border rounded p-2" />
+        {errors.lastWatered && (
+          <p className="text-sm text-red-600">{errors.lastWatered.message}</p>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Last fertilized</span>
+        <input
+          type="date"
+          {...register('lastFertilized')}
+          className="border rounded p-2"
+        />
+        {errors.lastFertilized && (
+          <p className="text-sm text-red-600">{errors.lastFertilized.message}</p>
         )}
       </label>
     </div>
@@ -103,6 +179,16 @@ export default function AddPlantForm({
     name: plantFieldSchemas.name,
     roomId: plantFieldSchemas.roomId,
     waterEvery: plantFieldSchemas.waterEvery,
+    waterAmount: plantFieldSchemas.waterAmount,
+    fertEvery: plantFieldSchemas.fertEvery,
+    lastWatered: plantFieldSchemas.lastWatered.transform((d) =>
+      d ? d.toISOString().slice(0, 10) : ''
+    ),
+    lastFertilized: plantFieldSchemas.lastFertilized.transform((d) =>
+      d ? d.toISOString().slice(0, 10) : ''
+    ),
+    lat: plantFieldSchemas.lat,
+    lon: plantFieldSchemas.lon,
     light: z.string(),
   });
   const {
@@ -118,6 +204,12 @@ export default function AddPlantForm({
         roomId: '',
         light: 'medium',
         waterEvery: 7,
+        waterAmount: 250,
+        fertEvery: 30,
+        lastWatered: '',
+        lastFertilized: '',
+        lat: undefined,
+        lon: undefined,
       },
   });
   const [step, setStep] = useState(0);
@@ -133,8 +225,8 @@ export default function AddPlantForm({
 
   const stepFields: (keyof AddPlantFormData)[][] = [
     ['name', 'roomId'],
-    ['light'],
-    ['waterEvery'],
+    ['light', 'lat', 'lon'],
+    ['waterEvery', 'waterAmount', 'fertEvery', 'lastWatered', 'lastFertilized'],
   ];
   const next = async () => {
     const fields = stepFields[step];

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -19,12 +19,25 @@ describe('AddPlantForm', () => {
 
     // Environment step
     await user.selectOptions(screen.getByLabelText(/light/i), 'medium');
+    await user.type(screen.getByLabelText(/latitude/i), '40.7');
+    await user.type(screen.getByLabelText(/longitude/i), '-74');
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     // Care step
     const waterInput = screen.getByLabelText(/water every/i);
     await user.clear(waterInput);
     await user.type(waterInput, '5');
+    const waterAmountInput = screen.getByLabelText(/water amount/i);
+    await user.clear(waterAmountInput);
+    await user.type(waterAmountInput, '300');
+    const fertEveryInput = screen.getByLabelText(/fertilize every/i);
+    await user.clear(fertEveryInput);
+    await user.type(fertEveryInput, '60');
+    await user.type(screen.getByLabelText(/last watered/i), '2024-01-01');
+    await user.type(
+      screen.getByLabelText(/last fertilized/i),
+      '2024-02-01'
+    );
     await user.click(screen.getByRole('button', { name: /add plant/i }));
 
     expect(handleSubmit).toHaveBeenCalled();
@@ -33,6 +46,12 @@ describe('AddPlantForm', () => {
       roomId: 'living',
       light: 'medium',
       waterEvery: 5,
+      waterAmount: 300,
+      fertEvery: 60,
+      lastWatered: '2024-01-01',
+      lastFertilized: '2024-02-01',
+      lat: 40.7,
+      lon: -74,
     });
   });
 
@@ -46,6 +65,12 @@ describe('AddPlantForm', () => {
           roomId: 'bedroom',
           light: 'low',
           waterEvery: 10,
+          waterAmount: 250,
+          fertEvery: 30,
+          lastWatered: '',
+          lastFertilized: '',
+          lat: undefined,
+          lon: undefined,
         }}
         submitLabel="Save"
       />


### PR DESCRIPTION
## Summary
- extend plant form schema and UI with water amount, fertilizer schedule, last care dates, and location
- send new care/location fields from plant create/edit pages
- test form inputs and edit submission round-trip through handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c9e027f08324ae58cf9666fb2bb2