### PR TITLE
feat: add stepper to plant form

### DIFF
--- a/components/forms/AddPlantForm.tsx
+++ b/components/forms/AddPlantForm.tsx
@@ -235,6 +235,12 @@ export default function AddPlantForm({
   };
   const back = () => setStep((s) => Math.max(s - 1, 0));
 
+  const handleStepClick = (i: number) => {
+    if (i <= step) {
+      setStep(i);
+    }
+  };
+
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -242,6 +248,34 @@ export default function AddPlantForm({
       noValidate
       className="flex flex-col gap-6"
     >
+      <nav aria-label="Progress" className="text-sm">
+        <ol className="flex items-center gap-2">
+          {steps.map((s, i) => (
+            <li key={s.title} className="flex items-center">
+              <button
+                type="button"
+                onClick={() => handleStepClick(i)}
+                disabled={i > step}
+                aria-current={i === step ? 'step' : undefined}
+                className={
+                  i === step
+                    ? 'font-semibold'
+                    : i > step
+                    ? 'text-neutral-400 cursor-not-allowed'
+                    : ''
+                }
+              >
+                {s.title}
+              </button>
+              {i < steps.length - 1 && (
+                <span aria-hidden="true" className="mx-2">
+                  →
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
       <h2 className="text-xl font-medium">{steps[step].title}</h2>
       {steps[step].component}
       <div className="flex gap-2">

--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -117,4 +117,29 @@ describe('AddPlantForm', () => {
     await user.click(screen.getByRole('button', { name: /add plant/i }));
     expect(handleSubmit).toHaveBeenCalled();
   });
+
+  it('shows stepper progress and allows navigating back via stepper', async () => {
+    const user = userEvent.setup();
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+    // initial step highlighted
+    expect(
+      screen.getByRole('button', { name: 'Basics' })
+    ).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByRole('button', { name: 'Environment' })).toBeDisabled();
+
+    // fill basics and advance
+    await user.type(screen.getByLabelText(/name/i), 'Ficus');
+    await user.selectOptions(screen.getByLabelText(/room/i), 'living');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(
+      screen.getByRole('button', { name: 'Environment' })
+    ).toHaveAttribute('aria-current', 'step');
+
+    // go back using stepper
+    await user.click(screen.getByRole('button', { name: 'Basics' }));
+    expect(
+      screen.getByRole('heading', { name: /basics/i })
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add progress stepper to AddPlantForm with clickable back navigation
- test stepper reflects current step and supports stepper-based back navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5cbb23cf48324bf2434d9aa1f9ba4