### PR TITLE
Fix resolver package resolution in Next.js build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 // Ensure Next.js transpiles ESM-only dependencies like react-hook-form
+// and associated resolver packages.
 const nextConfig = {
-  transpilePackages: ['react-hook-form'],
+  transpilePackages: ['react-hook-form', '@hookform/resolvers'],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- transpile `@hookform/resolvers` alongside `react-hook-form` so Next.js can resolve `@hookform/resolvers/zod`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53a870a708324aaf3fff23958e88f