### PR TITLE
Handle empty rooms in AddPlantForm

### DIFF
--- a/components/forms/__tests__/AddPlantForm.test.tsx
+++ b/components/forms/__tests__/AddPlantForm.test.tsx
@@ -164,4 +164,29 @@ describe('AddPlantForm', () => {
       screen.getByRole('heading', { name: /basics/i })
     ).toBeInTheDocument();
   });
+
+  it('disables next when no rooms and allows adding one', async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'office', name: 'Office' }),
+      });
+    global.fetch = fetchMock as any;
+
+    render(<AddPlantForm onSubmit={jest.fn()} />);
+
+    await screen.findByPlaceholderText(/add room/i);
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    expect(nextButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/name/i), 'Cactus');
+    await user.type(screen.getByPlaceholderText(/add room/i), 'Office');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await screen.findByRole('option', { name: 'Office' });
+    expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Summary
- add explicit error state when loading rooms fails
- let users add rooms on the Basics step and disable Next until a room exists
- test flow for creating a room when none exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e4d8334c832491dbee9a6c4762ed