### PR TITLE
refactor: centralize supabase client creation

### DIFF
--- a/app/app/AppShell.tsx
+++ b/app/app/AppShell.tsx
@@ -14,7 +14,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import { TaskDTO } from "@/lib/types";
 import { plantFormSchema } from "@/lib/plantFormSchema";
 
-import { createSupabaseClient } from "@/lib/supabase";
+import supabase from "@/lib/supabaseClient";
 import { subscribeToTaskChanges } from "@/lib/realtime";
 
 import { Button } from "@/components/ui/button";
@@ -759,7 +759,7 @@ export function TimelineView() {
 }
 
 export function SettingsView() {
-  const supabase = useRef(createSupabaseClient());
+  const supabaseRef = useRef(supabase);
   const singleUser = process.env.SINGLE_USER_MODE === "true";
   const router = useRouter();
 
@@ -915,7 +915,7 @@ export function SettingsView() {
   }
 
   async function handleSignOut() {
-    await supabase.current.auth.signOut();
+    await supabaseRef.current.auth.signOut();
     document.cookie = "sb-access-token=; Path=/; Max-Age=0";
     window.location.href = "/login";
   }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createSupabaseClient } from "@/lib/supabase";
+import supabase from "@/lib/supabaseClient";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -19,7 +19,6 @@ export default function LoginPage() {
     e.preventDefault();
     setError(null);
     try {
-      const supabase = createSupabaseClient();
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,8 +1,7 @@
-import { createSupabaseClient } from "./supabase";
+import supabase from "./supabaseClient";
 
 export function subscribeToTaskChanges(onChange: () => void) {
   try {
-    const supabase = createSupabaseClient();
     const channel = supabase
       .channel("tasks-db-changes")
       .on(
@@ -22,7 +21,6 @@ export function subscribeToTaskChanges(onChange: () => void) {
 
 export function subscribeToPlantChanges(onChange: () => void) {
   try {
-    const supabase = createSupabaseClient();
     const channel = supabase
       .channel("plants-db-changes")
       .on(

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,51 +1,14 @@
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./supabase.types";
-
-export function ensureSupabaseEnv() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anonKey) {
-    console.warn("Missing Supabase environment variables, using placeholders");
-    return { url: "http://localhost", anonKey: "anon" };
-  }
-  return { url, anonKey };
-}
-
-// Factory for an unauthenticated client
-export function createSupabaseClient(): SupabaseClient<Database> {
-  const { url, anonKey } = ensureSupabaseEnv();
-  const singleUserMode = process.env.SINGLE_USER_MODE === "true";
-  if (singleUserMode) {
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!serviceKey) {
-      throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY");
-    }
-    return createClient<Database>(url, serviceKey, {
-      auth: {
-        persistSession: false,
-        autoRefreshToken: false,
-      },
-    });
-  }
-  return createClient<Database>(url, anonKey);
-}
+import supabase from "./supabaseClient";
+export { ensureSupabaseEnv } from "./supabaseEnv";
 
 // Authenticated client helper for Route Handlers
 export async function createRouteHandlerClient(): Promise<SupabaseClient<Database>> {
   const { cookies } = await import("next/headers");
-  const { url, anonKey } = ensureSupabaseEnv();
   // `cookies()` is now asynchronous in Next 15 and must be awaited
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("sb-access-token")?.value;
-  return createClient<Database>(url, anonKey, {
-    global: {
-      headers: {
-        Authorization: accessToken ? `Bearer ${accessToken}` : "",
-      },
-    },
-    auth: {
-      persistSession: false,
-      autoRefreshToken: false,
-    },
-  });
+  supabase.auth.setAuth(accessToken ?? "");
+  return supabase;
 }

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,14 +1,19 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./supabase.types";
-import { ensureSupabaseEnv } from "./supabase";
+import { ensureSupabaseEnv } from "./supabaseEnv";
+
+const { url } = ensureSupabaseEnv();
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceKey) {
+  throw new Error("Missing Supabase environment variables");
+}
+
+const supabaseAdmin: SupabaseClient<Database> = createClient<Database>(
+  url,
+  serviceKey,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+);
 
 export function createSupabaseAdminClient(): SupabaseClient<Database> {
-  const { url } = ensureSupabaseEnv();
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!serviceKey) {
-    throw new Error("Missing Supabase environment variables");
-  }
-  return createClient<Database>(url, serviceKey, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  return supabaseAdmin;
 }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { ensureSupabaseEnv } from "./supabaseEnv";
+import type { Database } from "./supabase.types";
+
+const { url, anonKey } = ensureSupabaseEnv();
+const singleUserMode = process.env.SINGLE_USER_MODE === "true";
+
+let supabase: SupabaseClient<Database>;
+
+if (singleUserMode) {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY");
+  }
+  supabase = createClient<Database>(url, serviceKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+} else {
+  supabase = createClient<Database>(url, anonKey);
+}
+
+export default supabase;

--- a/lib/supabaseEnv.ts
+++ b/lib/supabaseEnv.ts
@@ -1,0 +1,9 @@
+export function ensureSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    console.warn("Missing Supabase environment variables, using placeholders");
+    return { url: "http://localhost", anonKey: "anon" };
+  }
+  return { url, anonKey };
+}


### PR DESCRIPTION
## Summary
- add `lib/supabaseClient.ts` exporting a singleton Supabase client
- update helpers and components to import the shared client instead of calling `createClient`
- cache service-role Supabase client for admin operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fd54edcc8324898d8aea96aedb71