### PR TITLE
feat: allow anon key fallback for single-user mode

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -9,6 +9,13 @@ export async function createRouteHandlerClient(): Promise<SupabaseClient<Databas
   // `cookies()` is now asynchronous in Next 15 and must be awaited
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("sb-access-token")?.value;
-  supabase.auth.setAuth(accessToken ?? "");
+  if (accessToken) {
+    const auth: any = supabase.auth as any;
+    if (typeof auth.setAuth === "function") {
+      auth.setAuth(accessToken);
+    } else if (typeof auth.setSession === "function") {
+      await auth.setSession({ access_token: accessToken, refresh_token: "" });
+    }
+  }
   return supabase;
 }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -10,9 +10,11 @@ let supabase: SupabaseClient<Database>;
 if (singleUserMode) {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!serviceKey) {
-    throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY");
+    console.warn(
+      "SINGLE_USER_MODE enabled without SUPABASE_SERVICE_ROLE_KEY; falling back to anon key with limited capabilities.",
+    );
   }
-  supabase = createClient<Database>(url, serviceKey, {
+  supabase = createClient<Database>(url, serviceKey ?? anonKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,


### PR DESCRIPTION
## Summary
- fall back to anon key when service role key missing in single-user mode
- warn developers when anon key is used and keep sessions disabled
- handle route-handler auth without depending on deprecated `setAuth`

## Testing
- `npm test`
- `curl -i localhost:3002/api/tasks` *(fails: {"error":"server"})*
- `curl -i localhost:3002/api/rooms` *(fails: {"error":"server"})*


------
https://chatgpt.com/codex/tasks/task_e_68a601102f248324b7f7699035fba6e7