### PR TITLE
Require auth for plant listing

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -2,16 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { listPlants, createPlant } from "@/lib/prisma/plants";
 import { createRouteHandlerClient } from "@/lib/supabase";
 import { getUserId } from "@/lib/getUserId";
+import { withAuth } from "@/lib/withAuth";
 import { z } from "zod";
 
 export async function GET(req: NextRequest) {
   try {
-    const { searchParams } = new URL(req.url);
-    const name = searchParams.get("name") || undefined;
-    const roomId = searchParams.get("roomId") || undefined;
-    const filter = name || roomId ? { name, roomId } : undefined;
-    const plants = await listPlants(filter);
-    return NextResponse.json(plants);
+    return await withAuth(async (_supabase, userId) => {
+      const { searchParams } = new URL(req.url);
+      const name = searchParams.get("name") || undefined;
+      const roomId = searchParams.get("roomId") || undefined;
+      const filter = name || roomId ? { name, roomId } : undefined;
+      const plants = await listPlants(userId, filter);
+      return NextResponse.json(plants);
+    });
   } catch (e: any) {
     console.error("GET /api/plants failed:", e);
     return NextResponse.json({ error: "server" }, { status: 500 });

--- a/lib/prisma/plants.ts
+++ b/lib/prisma/plants.ts
@@ -22,12 +22,16 @@ type PlantData = {
   lastFertilizedAt?: string | null;
 };
 
-export async function listPlants(filter?: {
-  name?: string;
-  roomId?: string;
-}): Promise<Plant[]> {
+export async function listPlants(
+  userId: string,
+  filter?: {
+    name?: string;
+    roomId?: string;
+  },
+): Promise<Plant[]> {
   return prisma.plant.findMany({
     where: {
+      userId,
       ...(filter?.name ? { name: filter.name } : {}),
       ...(filter?.roomId ? { roomId: filter.roomId } : {}),
     },


### PR DESCRIPTION
## Summary
- protect `GET /api/plants` with `withAuth` and scope queries by user
- update prisma `listPlants` to filter by `userId`
- expand tests to cover filters and unauthorized access

## Testing
- `npm test app/api/plants/route.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a60e321778832483204ed7074adb0f