### PR TITLE
docs: clarify SUPABASE_SERVICE_ROLE_KEY behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+# Without this key, automatic user provisioning is disabled
 DATABASE_URL="postgresql://user:password@host:5432/dbname"
 NEXT_PUBLIC_TASK_WINDOW_DAYS=7
 OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Kay Maria is intended to run in single-user mode by default.
 2. Create `.env` from `.env.example` and supply the mandatory values:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY` *(required for automatic user provisioning; omit to provision users manually)*
    - `NEXT_PUBLIC_BASE_URL`
    - `DATABASE_URL`
    - `SINGLE_USER_MODE=true`


### PR DESCRIPTION
## Summary
- highlight that missing SUPABASE_SERVICE_ROLE_KEY disables automatic user provisioning
- document the behavior in the example env file

## Testing
- `npm test | tail -n 20`
- `npm run dev >/tmp/dev.log &` (started and terminated)


------
https://chatgpt.com/codex/tasks/task_e_68a61bdd4b188324ba1487cf384cea82