### PR TITLE
Handle Next.js 15 Request URLs

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest) {
   }
   const { userId } = userRes;
 
-  const url = new URL(req.url);
+  const url = (req as any).nextUrl ?? new URL(req.url, "http://localhost");
   const offset = Number(url.searchParams.get("offset") || 0);
   const limit = Number(url.searchParams.get("limit") || 50);
 

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase";
 import { getUserId } from "@/lib/getUserId";
 
@@ -9,8 +9,8 @@ type InsightPoint = {
   overdueTaskCount: number;
 };
 
-export async function GET(req: Request) {
-  const url = new URL(req.url);
+export async function GET(req: NextRequest) {
+  const url = (req as any).nextUrl ?? new URL(req.url, "http://localhost");
   const startParam = url.searchParams.get("start");
   const endParam = url.searchParams.get("end");
 

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -8,9 +8,9 @@ import { z } from "zod";
 export async function GET(req: NextRequest) {
   try {
     return await withAuth(async (_supabase, userId) => {
-      const { searchParams } = new URL(req.url);
-      const name = searchParams.get("name") || undefined;
-      const roomId = searchParams.get("roomId") || undefined;
+      const url = (req as any).nextUrl ?? new URL(req.url, "http://localhost");
+      const name = url.searchParams.get("name") || undefined;
+      const roomId = url.searchParams.get("roomId") || undefined;
       const filter = name || roomId ? { name, roomId } : undefined;
       const plants = await listPlants(userId, filter);
       return NextResponse.json(plants);

--- a/app/api/species-care/route.ts
+++ b/app/api/species-care/route.ts
@@ -3,8 +3,8 @@ import { getCareDefaults } from '@/lib/species-care';
 
 export async function GET(req: NextRequest) {
   try {
-    const { searchParams } = new URL(req.url);
-    const species = searchParams.get('species') || '';
+    const url = (req as any).nextUrl ?? new URL(req.url, 'http://localhost');
+    const species = url.searchParams.get('species') || '';
     const key = species.trim().toLowerCase();
     const defaults = await getCareDefaults(species);
     if (!defaults) {

--- a/app/api/species-search/route.ts
+++ b/app/api/species-search/route.ts
@@ -3,8 +3,8 @@ import { SPECIES, SpeciesRecord } from '@/lib/species';
 
 export async function GET(req: NextRequest) {
   try {
-    const { searchParams } = new URL(req.url);
-    const q = (searchParams.get('q') || '').trim();
+    const url = (req as any).nextUrl ?? new URL(req.url, 'http://localhost');
+    const q = (url.searchParams.get('q') || '').trim();
     if (!q) {
       return NextResponse.json([]);
     }

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -3,7 +3,7 @@ import { withAuth } from "@/lib/withAuth";
 
 export async function GET(req: NextRequest) {
   return withAuth(async (supabase, userId) => {
-    const url = new URL(req.url);
+    const url = (req as any).nextUrl ?? new URL(req.url, "http://localhost");
     const win = url.searchParams.get("window") || "7d";
     const days = Number(win.replace("d", "")) || 7;
     const maxDate = new Date();


### PR DESCRIPTION
## Summary
- Parse query parameters from `req.nextUrl` with a fallback to `new URL(req.url, 'http://localhost')` to support Next.js 15 request objects
- Apply fix across tasks, plants, species search, events, insights and species care API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61ee76fc483248147be2371aedcc7