### PR TITLE
feat: add due tasks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Kay Maria is intended to run in single-user mode by default.
    ```
    The `npm run db:seed` script only clears the `task` and `plant` tables and doesn’t insert mock data. Run it only if you need to wipe existing data.
    Routes under `/app` now require authentication and redirect to `/login` when no session is present. Log in at `http://localhost:3000/login` with a Supabase email/password account. Use the Settings page to sign out.
+5. Query upcoming tasks
+   ```bash
+   curl http://localhost:3000/api/tasks/due
+   ```
+   In single-user mode this works without additional auth. In multi-user setups, include an `sb-access-token` cookie from a logged-in session.
 
 ## Post-merge workflow
 After pulling new changes:

--- a/app/api/tasks/due/route.ts
+++ b/app/api/tasks/due/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/withAuth";
+
+// Return all tasks due in the next 7 days for the authenticated user.
+export async function GET() {
+  return withAuth(async (supabase, userId) => {
+    const maxDate = new Date();
+    maxDate.setDate(maxDate.getDate() + 7);
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .select("id, type, due_at, last_done_at, plant:plants(id, name, room_id)")
+      .eq("user_id", userId)
+      .lte("due_at", maxDate.toISOString())
+      .order("due_at");
+    if (error) {
+      console.error("GET /api/tasks/due failed:", error);
+      return NextResponse.json({ error: "server" }, { status: 500 });
+    }
+
+    const tasks = (data || []).map((t: any) => ({
+      id: t.id,
+      plantId: t.plant?.id ?? t.plant_id,
+      plantName: t.plant?.name ?? "",
+      roomId: t.plant?.room_id ?? "",
+      type: t.type,
+      dueAt: t.due_at,
+      status: "due",
+      lastEventAt: t.last_done_at || null,
+    }));
+
+    return NextResponse.json(tasks);
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/tasks/due` route to fetch tasks due in next 7 days with auth
- document how to query upcoming tasks endpoint in README

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist... run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68a625343a288324b4e7af4eacece731