### PR TITLE
Auto-generate single user ID in single-user mode

### DIFF
--- a/lib/__tests__/getUserId.test.ts
+++ b/lib/__tests__/getUserId.test.ts
@@ -19,12 +19,13 @@ describe("getUserId", () => {
     jest.clearAllMocks();
   });
 
-  it("returns misconfigured when SINGLE_USER_ID is missing", async () => {
+  it("generates id when SINGLE_USER_ID is missing", async () => {
     process.env.SINGLE_USER_MODE = "true";
     const supabase = mockSupabase();
 
     const res = await getUserId(supabase);
-    expect(res).toEqual({ error: "misconfigured" });
+    expect(res).toEqual({ userId: expect.any(String) });
+    expect(process.env.SINGLE_USER_ID).toBeDefined();
     expect(supabase.auth.getUser).not.toHaveBeenCalled();
   });
 

--- a/lib/getUserId.ts
+++ b/lib/getUserId.ts
@@ -16,12 +16,11 @@ export async function getUserId(
   const singleUser = process.env.SINGLE_USER_MODE === 'true';
 
   if (singleUser) {
-    const userId = process.env.SINGLE_USER_ID;
+    let userId = process.env.SINGLE_USER_ID;
     if (!userId) {
-      console.error(
-        'SINGLE_USER_MODE enabled but SINGLE_USER_ID not set'
-      );
-      return { error: 'misconfigured' };
+      userId = randomUUID();
+      process.env.SINGLE_USER_ID = userId;
+      console.warn('SINGLE_USER_ID not set, generated temporary id');
     }
 
     if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {


### PR DESCRIPTION
## Summary
- Generate a temporary user ID if `SINGLE_USER_MODE` is enabled without `SINGLE_USER_ID`
- Update API and unit tests to cover automatic user ID generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6263068b483249ba220c7865db2d4